### PR TITLE
feat(cli): Add --json flag to yazses status (#1)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -121,10 +121,12 @@ yazses stop    # dictation off until you start again
 
 Show state, hotkey, model, injection backend, and uptime over IPC. When not
 running, points you at `yazses start` (and `yazses quickstart` for new users);
-while the model is still loading it says so rather than looking broken.
+while the model is still loading it says so rather than looking broken. Pass `--json`
+for machine-readable JSON output for status bars or scripts.
 
 ```bash
-yazses status    # is it running? show state, model, and hotkey
+yazses status         # is it running? show state, model, and hotkey
+yazses status --json  # output state, pid, model, and ready as JSON
 ```
 
 ### `yazses tray`

--- a/src/yazses/cli.py
+++ b/src/yazses/cli.py
@@ -1639,12 +1639,24 @@ def stop() -> None:
 
 @app.command(
     rich_help_panel=_DAEMON,
-    epilog=_examples("yazses status    show state, model, hotkey, and uptime"),
+    epilog=_examples(
+        "yazses status         show state, model, hotkey, and uptime",
+        "yazses status --json  dump status as JSON for scripts and status bars",
+    ),
 )
-def status() -> None:
+def status(
+    json_output: bool = typer.Option(
+        False, "--json", help="Output status as JSON for scripts and status bars."
+    ),
+) -> None:
     """Show daemon status. Queries the daemon over IPC when reachable."""
+    import json as _json
+
     platform = get_platform()
     if not platform.lifecycle.is_running():
+        if json_output:
+            typer.echo(_json.dumps({"running": False, "state": "stopped", "pid": None, "ready": False}))
+            return
         typer.echo("YazSes is not running. Start it with `yazses start`.")
         typer.echo("New here? Run `yazses quickstart` for the 3-step setup.")
         return
@@ -1654,10 +1666,23 @@ def status() -> None:
     try:
         info = client.call("status")
     except IpcUnreachableError:
+        if json_output:
+            typer.echo(_json.dumps({"running": True, "state": "starting", "pid": pid, "ready": False}))
+            return
         typer.echo(
             f"YazSes is running (PID {pid}) but still starting up — it's loading the "
             "speech model (first run can take 10–30s). Re-run `yazses status` shortly."
         )
+        return
+
+    if json_output:
+        data = dict(info)
+        data["running"] = True
+        data["pid"] = pid
+        if "ready" not in data:
+            state = str(data.get("state", "")).lower()
+            data["ready"] = state in ("idle", "recording", "injecting")
+        typer.echo(_json.dumps(data))
         return
 
     typer.echo(f"YazSes is running (PID {pid}).")

--- a/tests/test_cli_quickstart.py
+++ b/tests/test_cli_quickstart.py
@@ -109,6 +109,69 @@ def test_status_not_running_is_actionable(monkeypatch):
     assert "quickstart" in result.output  # points a new user at onboarding
 
 
+def test_status_json_not_running(monkeypatch):
+    import json
+    plat = _Platform(running=False)
+    _patch(monkeypatch, plat)
+    result = runner.invoke(cli.app, ["status", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["running"] is False
+    assert data["state"] == "stopped"
+    assert data["pid"] is None
+    assert data["ready"] is False
+
+
+def test_status_json_running(monkeypatch):
+    import json
+    plat = _Platform(running=True)
+    _patch(monkeypatch, plat)
+    mock_status = {
+        "state": "idle",
+        "ready": True,
+        "model": "base.en",
+        "hotkey": "right_ctrl",
+        "injection_backend": "uinput",
+        "uptime_s": 42.0,
+    }
+
+    class _MockClient:
+        def call(self, method):
+            if method == "status":
+                return mock_status
+            raise RuntimeError(f"Unexpected method: {method}")
+
+    plat.ipc_client_factory = lambda _sock: _MockClient()
+    result = runner.invoke(cli.app, ["status", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["running"] is True
+    assert data["pid"] == 4321
+    assert data["state"] == "idle"
+    assert data["ready"] is True
+    assert data["model"] == "base.en"
+    assert data["hotkey"] == "right_ctrl"
+
+
+def test_status_json_starting_ipc_unreachable(monkeypatch):
+    import json
+    plat = _Platform(running=True)
+    _patch(monkeypatch, plat)
+
+    class _MockClientUnreachable:
+        def call(self, method):
+            raise cli.IpcUnreachableError("Socket unreachable")
+
+    plat.ipc_client_factory = lambda _sock: _MockClientUnreachable()
+    result = runner.invoke(cli.app, ["status", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["running"] is True
+    assert data["state"] == "starting"
+    assert data["pid"] == 4321
+    assert data["ready"] is False
+
+
 def test_stop_not_running_says_nothing_to_stop(monkeypatch):
     plat = _Platform(running=False)
     _patch(monkeypatch, plat)


### PR DESCRIPTION
## Context & Fix

Closes #1

This PR adds a  flag to  to output machine-readable JSON representation of the daemon status for scripts, status bars, and automated tools.

### Changes Made:
1. Added  option flag to  command in .
2. Returned structured JSON object containing , , , , , and IPC status fields when  is supplied (handling not running, starting, and active daemon states).
3. Updated CLI reference documentation in .
4. Added comprehensive unit tests in  asserting JSON structure and key presence across stopped, starting, and running states. Verified all unit tests pass cleanly with pytest.