### PR TITLE
docs: add demo GIF recording guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ pipx install yazses
 | [Install on Windows](docs/windows-install.md) | SmartScreen, antivirus exceptions, privacy settings |
 | [CLI reference](docs/cli-reference.md) | All commands and flags (incl. macros & vocabulary for custom voice commands) |
 | [Privacy statement](docs/privacy-statement.md) | What stays on-device, what is never collected |
-
+| [Record your own demo GIF](docs/demo-guide.md) | How to capture a short hold-to-talk demo GIF |
 ---
 
 ## Development

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -17,15 +17,12 @@ Keep the recording short and focused so the resulting GIF is easy to view.
 
 ## Recording Tools
 
-You can use any screen recorder that can capture a selected region or window.
+Choose a recording tool based on your Linux display system:
 
-Some options include:
-
-- **Peek** — a simple GIF recorder for Linux.
-- **wf-recorder** — a screen recorder for Wayland.
-- **gifski** — converts recorded video frames into high-quality GIFs.
-
-Choose whichever tool works best for your operating system and desktop environment.
+- **Peek** — a simple option for recording short demos, commonly used on X11.
+- **wf-recorder** — a screen recorder designed for Wayland.
+- **gifski** — converts recorded video frames into a high-quality, optimized GIF.
+- **ffmpeg** — can also be used to convert a screen recording into GIF format.
 
 ## Recording the Demo
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -1,0 +1,50 @@
+# Record Your Own Demo GIF
+
+A short demo GIF is a convenient way to show YazSes hold-to-talk dictation in action. This guide explains how to record your own demo.
+
+## What to Record
+
+A useful demo should clearly show:
+
+1. Start YazSes.
+2. Place the cursor in a text field or editor.
+3. Hold the configured hold-to-talk key.
+4. Speak a short sentence.
+5. Release the key.
+6. Show the transcribed text appearing in the active window.
+
+Keep the recording short and focused so the resulting GIF is easy to view.
+
+## Recording Tools
+
+You can use any screen recorder that can capture a selected region or window.
+
+Some options include:
+
+- **Peek** — a simple GIF recorder for Linux.
+- **wf-recorder** — a screen recorder for Wayland.
+- **gifski** — converts recorded video frames into high-quality GIFs.
+
+Choose whichever tool works best for your operating system and desktop environment.
+
+## Recording the Demo
+
+Before recording:
+
+- Open YazSes and make sure dictation is working.
+- Open the application where you want the dictated text to appear.
+- Resize the windows so only the relevant area needs to be recorded.
+- Avoid displaying private or sensitive information.
+
+Start your screen recorder, demonstrate the hold-to-talk workflow, and stop recording once the transcribed text appears.
+
+## Tips for a Good Demo
+
+- Keep the GIF short.
+- Record only the relevant part of the screen.
+- Make the dictated text easy to read.
+- Avoid unnecessary mouse movement.
+- Remove or hide personal information before recording.
+- Compress the GIF when possible to keep the file size small.
+
+Once your GIF is ready, it can be used in documentation, bug reports, or feature demonstrations.


### PR DESCRIPTION
## Summary

- Added `docs/demo-guide.md` with a short guide for recording a hold-to-talk demo GIF.
- Included recording options for X11 and Wayland.
- Included tools for converting recordings into optimized GIFs.
- Linked the new guide from the README documentation section.

Closes #5

## Testing

Not run — documentation-only change.