### PR TITLE
feat(cli): add --json to yazses meeting list

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -788,6 +788,7 @@ yazses meeting start               # begin hands-free capture
 yazses meeting status              # elapsed + live rolling transcript
 yazses meeting stop                # diarize + write the labelled transcript
 yazses meeting list                # see stored meetings
+yazses meeting list --json         # machine-readable array
 yazses meeting relabel <id> --rename speaker_1=Alice --merge speaker_2=speaker_1
 yazses meeting notes <id>          # local-LLM minutes (needs notes_model)
 ```

--- a/docs/command-index.md
+++ b/docs/command-index.md
@@ -250,6 +250,8 @@ Enroll a meeting speaker as a named voiceprint so they're auto-named next time.
 
 List stored meetings on this machine (no daemon required).
 
+- `--json` — Print meetings as a JSON array (machine-readable; empty list is []).
+
 ### `yazses meeting notes`
 
 Generate meeting minutes (summary, decisions, action items) from the transcript.

--- a/src/yazses/cli.py
+++ b/src/yazses/cli.py
@@ -188,13 +188,24 @@ def meeting_status() -> None:
 
 
 @meeting_app.command("list")
-def meeting_list() -> None:
+def meeting_list(
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Print meetings as a JSON array (machine-readable; empty list is []).",
+    ),
+) -> None:
     """List stored meetings on this machine (no daemon required)."""
+    import json
+
     from yazses.config import load_config
     from yazses.meeting import store
 
     cfg = load_config(get_platform().paths.config_file)
     meetings = store.list_meetings(cfg.meeting)
+    if as_json:
+        typer.echo(json.dumps(meetings, ensure_ascii=False, default=str))
+        return
     if not meetings:
         typer.echo("No meetings found.")
         return

--- a/tests/test_meeting_list_json.py
+++ b/tests/test_meeting_list_json.py
@@ -1,0 +1,53 @@
+"""yazses meeting list --json (issue #49)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from yazses.cli import app
+
+
+def test_meeting_list_json_empty(tmp_path: Path) -> None:
+    meetings_root = tmp_path / "meetings"
+    meetings_root.mkdir()
+    fake_cfg = mock.Mock()
+    fake_cfg.meeting = mock.Mock()
+    fake_cfg.meeting.output_dir = str(meetings_root)
+
+    with mock.patch("yazses.config.load_config", return_value=fake_cfg), mock.patch(
+        "yazses.cli.get_platform"
+    ) as gp:
+        gp.return_value.paths.config_file = tmp_path / "cfg.toml"
+        result = CliRunner().invoke(app, ["meeting", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == []
+
+
+def test_meeting_list_json_contains_ids(tmp_path: Path) -> None:
+    meetings_root = tmp_path / "meetings"
+    m1 = meetings_root / "20260101T120000"
+    m1.mkdir(parents=True)
+    (m1 / "meeting.json").write_text(
+        json.dumps({"id": "20260101T120000", "num_speakers": 2, "has_notes": False}),
+        encoding="utf-8",
+    )
+
+    fake_cfg = mock.Mock()
+    fake_cfg.meeting = mock.Mock()
+    fake_cfg.meeting.output_dir = str(meetings_root)
+
+    with mock.patch("yazses.config.load_config", return_value=fake_cfg), mock.patch(
+        "yazses.cli.get_platform"
+    ) as gp:
+        gp.return_value.paths.config_file = tmp_path / "cfg.toml"
+        result = CliRunner().invoke(app, ["meeting", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert any(item.get("id") == "20260101T120000" for item in data)


### PR DESCRIPTION
## Summary
`yazses meeting list` had no machine-readable form for scripting.

## Changes
- Add `--json` flag that dumps meeting records as a JSON array
- Empty result prints `[]` with no prose
- Tests for empty list and expected ids
- Regenerated `docs/command-index.md` (and a small cli-reference example)

Closes #49