### PR TITLE
types: fix mypy errors in commands/grammar.py

### DIFF
--- a/src/yazses/commands/grammar.py
+++ b/src/yazses/commands/grammar.py
@@ -1,11 +1,10 @@
 """Code command grammar classifier — detects voice commands in transcribed text."""
 from __future__ import annotations
 
-from typing import Protocol
-
 import re
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Protocol
 
 
 class IntentType(str, Enum):
@@ -110,7 +109,12 @@ _add(r'^new\s+file\s+(?:called?\s+)?(.+)$', IntentType.EDIT, "new_file", ["name"
 
 
 class _MacroHit(Protocol):
-    trigger: str
+    # Read-only on purpose: the real collaborator is `commands.macros.Macro`, a
+    # frozen dataclass. A bare `trigger: str` here would declare a *settable*
+    # attribute, and those are invariant — a frozen dataclass cannot satisfy it,
+    # which pushes the type error out to the daemon's classify() call sites.
+    @property
+    def trigger(self) -> str: ...
 
 
 class _MacroTable(Protocol):

--- a/src/yazses/commands/grammar.py
+++ b/src/yazses/commands/grammar.py
@@ -1,6 +1,8 @@
 """Code command grammar classifier — detects voice commands in transcribed text."""
 from __future__ import annotations
 
+from typing import Protocol
+
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -107,11 +109,19 @@ _add(r'^new\s+class\s+(?:called?\s+)?(.+)$', IntentType.EDIT, "new_class", ["nam
 _add(r'^new\s+file\s+(?:called?\s+)?(.+)$', IntentType.EDIT, "new_file", ["name"])
 
 
+class _MacroTable(Protocol):
+    def match(self, text: str) -> object | None: ...
+
+
+class _SlmRouter(Protocol):
+    def classify(self, text: str, profile: str) -> CommandIntent | None: ...
+
+
 def classify(
     text: str,
     profile: str = "default",
-    slm_router: object | None = None,
-    macro_table: object | None = None,
+    slm_router: _SlmRouter | None = None,
+    macro_table: _MacroTable | None = None,
 ) -> CommandIntent:
     """Classify transcribed text as a command or plain dictation.
 
@@ -125,7 +135,7 @@ def classify(
 
     # Tier 0: user-defined macros (run before the regex grammar).
     if macro_table is not None:
-        macro = macro_table.match(text)  # type: ignore[union-attr]
+        macro = macro_table.match(text)
         if macro is not None:
             return CommandIntent(
                 intent=IntentType.MACRO,
@@ -148,7 +158,7 @@ def classify(
             return CommandIntent(intent=intent, action=action, args=args, raw_text=text)
 
     if slm_router is not None:
-        slm_result = slm_router.classify(text, profile)  # type: ignore[union-attr]
+        slm_result = slm_router.classify(text, profile)
         if slm_result is not None:
             return slm_result
 

--- a/src/yazses/commands/grammar.py
+++ b/src/yazses/commands/grammar.py
@@ -109,8 +109,12 @@ _add(r'^new\s+class\s+(?:called?\s+)?(.+)$', IntentType.EDIT, "new_class", ["nam
 _add(r'^new\s+file\s+(?:called?\s+)?(.+)$', IntentType.EDIT, "new_file", ["name"])
 
 
+class _MacroHit(Protocol):
+    trigger: str
+
+
 class _MacroTable(Protocol):
-    def match(self, text: str) -> object | None: ...
+    def match(self, text: str) -> _MacroHit | None: ...
 
 
 class _SlmRouter(Protocol):


### PR DESCRIPTION
## Summary
`classify()` took `object | None` for optional routers, so mypy reported attr-defined errors on `.match` / `.classify` after None checks.

## Changes
- Introduce small `_MacroTable` / `_SlmRouter` Protocols
- Drop obsolete type: ignore comments

Closes #47