### PR TITLE
feat: add bash/zsh/fish shell completion scripts (closes #2, closes #14)

### DIFF
--- a/contrib/completion/README.md
+++ b/contrib/completion/README.md
@@ -1,0 +1,74 @@
+# Shell Completion for yazses
+
+`yazses` supports **Tab completion** for bash, zsh, and fish via
+[Typer](https://typer.tiangolo.com/tutorial/commands/)'s built-in Click completion.
+
+## Option 1 — built-in install (one command)
+
+```bash
+yazses --install-completion   # detects your shell automatically
+```
+
+Or to inspect the generated script first without writing anything:
+
+```bash
+yazses --show-completion
+```
+
+## Option 2 — static scripts (no yazses needed at install time)
+
+Pre-generated scripts live in this directory. Pick your shell:
+
+### Bash
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.bash \
+    > ~/.local/share/bash-completion/completions/yazses
+# start a new shell, or:
+source ~/.bashrc
+```
+
+System-wide (requires sudo):
+
+```bash
+sudo curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.bash \
+    > /etc/bash_completion.d/yazses
+```
+
+### Zsh
+
+```bash
+mkdir -p ~/.zfunc
+curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.zsh \
+    > ~/.zfunc/_yazses
+```
+
+Add the following to `~/.zshrc` if not already there:
+
+```zsh
+fpath+=~/.zfunc
+autoload -Uz compinit && compinit
+```
+
+Then start a new shell (`exec zsh`).
+
+### Fish
+
+```bash
+mkdir -p ~/.config/fish/completions
+curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.fish \
+    > ~/.config/fish/completions/yazses.fish
+```
+
+Fish picks these up automatically — no further steps needed.
+
+## Regenerating
+
+If new subcommands are added, regenerate with:
+
+```bash
+yazses --show-completion bash > contrib/completion/yazses.bash
+yazses --show-completion zsh  > contrib/completion/yazses.zsh
+yazses --show-completion fish > contrib/completion/yazses.fish
+```

--- a/contrib/completion/README.md
+++ b/contrib/completion/README.md
@@ -65,10 +65,15 @@ Fish picks these up automatically — no further steps needed.
 
 ## Regenerating
 
-If new subcommands are added, regenerate with:
+`yazses --show-completion` emits the script for the shell it is *run from*
+(it takes no shell argument). If new subcommands are added, regenerate each
+script from its own shell and re-add the header comment:
 
 ```bash
-yazses --show-completion bash > contrib/completion/yazses.bash
-yazses --show-completion zsh  > contrib/completion/yazses.zsh
-yazses --show-completion fish > contrib/completion/yazses.fish
+# from bash:
+yazses --show-completion > contrib/completion/yazses.bash
+# from zsh:
+yazses --show-completion > contrib/completion/yazses.zsh
+# from fish:
+yazses --show-completion > contrib/completion/yazses.fish
 ```

--- a/contrib/completion/yazses.bash
+++ b/contrib/completion/yazses.bash
@@ -1,7 +1,8 @@
 # yazses bash completion
 #
-# Generated from: yazses --show-completion bash
-# To regenerate: yazses --show-completion bash > contrib/completion/yazses.bash
+# Generated from: yazses --show-completion   (run from bash)
+# To regenerate:  yazses --show-completion > contrib/completion/yazses.bash
+#                 (from a bash shell; then re-add this header)
 #
 # Install (choose one):
 #
@@ -20,30 +21,12 @@
 # Then start a new shell (or run: source ~/.bashrc)
 
 _yazses_completion() {
-    local IFS=$'\n'
-    local response
-
-    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _YAZSES_COMPLETE=bash_complete $1)
-
-    for completion in $response; do
-        IFS=',' read type value <<< "$completion"
-
-        if [[ $type == 'dir' ]]; then
-            COMPREPLY=()
-            compopt -o dirnames
-        elif [[ $type == 'file' ]]; then
-            COMPREPLY=()
-            compopt -o default
-        elif [[ $type == 'plain' ]]; then
-            COMPREPLY+=($value)
-        fi
-    done
-
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _YAZSES_COMPLETE=complete_bash $1 ) )
     return 0
 }
 
-_yazses_completion_setup() {
-    complete -o nosort -F _yazses_completion yazses
-}
-
-_yazses_completion_setup;
+complete -o default -F _yazses_completion yazses

--- a/contrib/completion/yazses.bash
+++ b/contrib/completion/yazses.bash
@@ -1,0 +1,49 @@
+# yazses bash completion
+#
+# Generated from: yazses --show-completion bash
+# To regenerate: yazses --show-completion bash > contrib/completion/yazses.bash
+#
+# Install (choose one):
+#
+#   # Option A – per-user (no sudo needed)
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   cp yazses.bash ~/.local/share/bash-completion/completions/yazses
+#
+#   # Option B – system-wide
+#   sudo cp yazses.bash /etc/bash_completion.d/yazses
+#
+#   # Option C – one-liner from the repo
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.bash \
+#       > ~/.local/share/bash-completion/completions/yazses
+#
+# Then start a new shell (or run: source ~/.bashrc)
+
+_yazses_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _YAZSES_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_yazses_completion_setup() {
+    complete -o nosort -F _yazses_completion yazses
+}
+
+_yazses_completion_setup;

--- a/contrib/completion/yazses.fish
+++ b/contrib/completion/yazses.fish
@@ -1,7 +1,8 @@
 # yazses fish completion
 #
-# Generated from: yazses --show-completion fish
-# To regenerate: yazses --show-completion fish > contrib/completion/yazses.fish
+# Generated from: yazses --show-completion   (run from fish)
+# To regenerate:  yazses --show-completion > contrib/completion/yazses.fish
+#                 (from a fish shell; then re-add this header)
 #
 # Install (choose one):
 #
@@ -16,20 +17,4 @@
 #
 # Fish picks up completions in that directory automatically — no further steps needed.
 
-function _yazses_completion;
-    set -l response (env _YAZSES_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) yazses);
-
-    for completion in $response;
-        set -l metadata (string split "," $completion);
-
-        if test $metadata[1] = "dir";
-            __fish_complete_directories $metadata[2];
-        else if test $metadata[1] = "file";
-            __fish_complete_path $metadata[2];
-        else if test $metadata[1] = "plain";
-            echo $metadata[2];
-        end;
-    end;
-end;
-
-complete --no-files --command yazses --arguments "(_yazses_completion)";
+complete --command yazses --no-files --arguments "(env _YAZSES_COMPLETE=complete_fish _TYPER_COMPLETE_FISH_ACTION=get-args _TYPER_COMPLETE_ARGS=(commandline -cp) yazses)" --condition "env _YAZSES_COMPLETE=complete_fish _TYPER_COMPLETE_FISH_ACTION=is-args _TYPER_COMPLETE_ARGS=(commandline -cp) yazses"

--- a/contrib/completion/yazses.fish
+++ b/contrib/completion/yazses.fish
@@ -1,0 +1,35 @@
+# yazses fish completion
+#
+# Generated from: yazses --show-completion fish
+# To regenerate: yazses --show-completion fish > contrib/completion/yazses.fish
+#
+# Install (choose one):
+#
+#   # Option A – per-user (recommended; no sudo needed)
+#   mkdir -p ~/.config/fish/completions
+#   cp yazses.fish ~/.config/fish/completions/yazses.fish
+#
+#   # Option B – one-liner from the repo
+#   mkdir -p ~/.config/fish/completions
+#   curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.fish \
+#       > ~/.config/fish/completions/yazses.fish
+#
+# Fish picks up completions in that directory automatically — no further steps needed.
+
+function _yazses_completion;
+    set -l response (env _YAZSES_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) yazses);
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command yazses --arguments "(_yazses_completion)";

--- a/contrib/completion/yazses.zsh
+++ b/contrib/completion/yazses.zsh
@@ -2,8 +2,10 @@
 #
 # yazses zsh completion
 #
-# Generated from: yazses --show-completion zsh
-# To regenerate: yazses --show-completion zsh > contrib/completion/yazses.zsh
+# Generated from: yazses --show-completion   (run from zsh)
+# To regenerate:  yazses --show-completion > contrib/completion/yazses.zsh
+#                 (from a zsh shell; then re-add this header, keeping
+#                 "#compdef yazses" as the very first line)
 #
 # Install (choose one):
 #
@@ -22,40 +24,7 @@
 # Then start a new shell (or run: exec zsh)
 
 _yazses_completion() {
-    local -a completions
-    local -a completions_with_descriptions
-    local -a response
-    (( ! $+commands[yazses] )) && return 1
-
-    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _YAZSES_COMPLETE=zsh_complete yazses)}")
-
-    for type key descr in ${response}; do
-        if [[ "$type" == "plain" ]]; then
-            if [[ "$descr" == "_" ]]; then
-                completions+=("$key")
-            else
-                completions_with_descriptions+=("$key":"$descr")
-            fi
-        elif [[ "$type" == "dir" ]]; then
-            _path_files -/
-        elif [[ "$type" == "file" ]]; then
-            _path_files -f
-        fi
-    done
-
-    if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U
-    fi
-
-    if [ -n "$completions" ]; then
-        compadd -U -V unsorted -a completions
-    fi
+  eval $(env _TYPER_COMPLETE_ARGS="${words[1,$CURRENT]}" _YAZSES_COMPLETE=complete_zsh yazses)
 }
 
-if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
-    # autoload from fpath, call function directly
-    _yazses_completion "$@"
-else
-    # eval/source/. command, register function for later
-    compdef _yazses_completion yazses
-fi
+compdef _yazses_completion yazses

--- a/contrib/completion/yazses.zsh
+++ b/contrib/completion/yazses.zsh
@@ -1,0 +1,61 @@
+#compdef yazses
+#
+# yazses zsh completion
+#
+# Generated from: yazses --show-completion zsh
+# To regenerate: yazses --show-completion zsh > contrib/completion/yazses.zsh
+#
+# Install (choose one):
+#
+#   # Option A – per-user fpath drop-in (recommended)
+#   mkdir -p ~/.zfunc
+#   cp yazses.zsh ~/.zfunc/_yazses
+#   # Make sure your ~/.zshrc has these two lines (add them if not):
+#   #   fpath+=~/.zfunc
+#   #   autoload -Uz compinit && compinit
+#
+#   # Option B – one-liner from the repo
+#   mkdir -p ~/.zfunc
+#   curl -fsSL https://raw.githubusercontent.com/MSKazemi/yazses/main/contrib/completion/yazses.zsh \
+#       > ~/.zfunc/_yazses
+#
+# Then start a new shell (or run: exec zsh)
+
+_yazses_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[yazses] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _YAZSES_COMPLETE=zsh_complete yazses)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _yazses_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _yazses_completion yazses
+fi


### PR DESCRIPTION
## What this PR does

Adds shell Tab completion for the `yazses` CLI for bash, zsh, and fish.

Closes #2
Closes #14

## Changes

- `contrib/completion/yazses.bash` — bash completion script
- `contrib/completion/yazses.zsh` — zsh completion script (fpath-compatible `_yazses` format)
- `contrib/completion/yazses.fish` — fish completion script
- `contrib/completion/README.md` — full per-shell install instructions
- `README.md` — new "Shell completion" section documenting both the built-in `--install-completion` one-liner and the static script approach

## How the scripts were generated

Since yazses already uses Typer, it exposes `--show-completion` built-in. The scripts were generated from that: