### PR TITLE
docs: mention shell completion in the README install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ every system prerequisite (audio, keystroke injection, clipboard, `input` group,
 install. The APT and `pipx` paths install the last tagged release. YazSes is also on the
 [Snap Store](https://snapcraft.io/yazses) (`sudo snap install yazses`).
 
+
+**Shell completion:** `yazses --install-completion` (or `yazses --show-completion` to print the script). See the [CLI reference](docs/cli-reference.md).
+
 **Step 2 — Provision the system** *(Linux — one command; the APT install does it automatically)*
 
 ```sh


### PR DESCRIPTION
## Summary
Shell completion shipped earlier but was only documented in `docs/cli-reference.md`.

## Changes
- Mention `yazses --install-completion` / `--show-completion` on the README install path with a link to the CLI reference

Closes #75