### PR TITLE
fix(macos): the .dmg is arm64-only, the .app claimed v0.1.2, and brew install 404'd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,27 @@ script and the Python entry point together on Linux CI, where the suite actually
 release so far. It is `%LOCALAPPDATA%\Programs\YazSes` — the documented path never existed,
 so the uninstaller and CLI instructions pointed nowhere.
 
+### Added — `brew install --cask yazses` works, via a real tap
+
+The cask has existed in `packaging/homebrew/` since v1, and `brew install yazses` has
+404'd that entire time, because a manifest that never reaches a registry installs nobody.
+The tap is now published at
+**[MSKazemi/homebrew-yazses](https://github.com/MSKazemi/homebrew-yazses)**:
+
+```sh
+brew tap MSKazemi/yazses
+brew install --cask yazses
+```
+
+`Casks/yazses.rb` there is byte-identical to `packaging/homebrew/yazses.rb`, which stays
+the source of truth; copying it across is a step in the post-release checklist in
+`packaging/README.md`. Closes [#6](https://github.com/MSKazemi/yazses/issues/6).
+
+Apple Silicon only — see the architecture note below. The install itself has **not** been
+run end to end, because casks only install on macOS; what is verified is that the tap is
+public, the cask is served intact, and the `.dmg` URL and checksum match the released
+asset.
+
 ### Fixed — every macOS `.app` since v0.1.3 told the OS it was version 0.1.2
 
 `packaging/macos/yazses.spec` set `CFBundleVersion` and `CFBundleShortVersionString` as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,47 @@ script and the Python entry point together on Linux CI, where the suite actually
 release so far. It is `%LOCALAPPDATA%\Programs\YazSes` — the documented path never existed,
 so the uninstaller and CLI instructions pointed nowhere.
 
+### Fixed — every macOS `.app` since v0.1.3 told the OS it was version 0.1.2
+
+`packaging/macos/yazses.spec` set `CFBundleVersion` and `CFBundleShortVersionString` as
+string literals, and they were last touched at v0.1.2. Every `.dmg` from v0.1.3 through
+v2.18.0 therefore shipped a bundle that reported **0.1.2** to macOS. Finder's *Get Info*,
+`mdls`, and anything comparing `CFBundleShortVersionString` all read that number, so a
+genuine upgrade looked like a downgrade.
+
+Nothing surfaced it because the value is only observable on a built `.app`, which requires
+a Mac. The spec now reads the version from `pyproject.toml`, so the two cannot drift, and
+`tests/test_packaging_macos.py` fails if the literal ever comes back.
+
+### Fixed — the Homebrew cask was a release behind, and would have installed a broken app on Intel
+
+Two independent problems in `packaging/homebrew/yazses.rb`:
+
+**Stale.** It pinned `2.17.0` and that release's checksum while `2.18.0` was current.
+Homebrew verifies the digest, so this is not a cosmetic lag — the download is refused and
+the first thing a new user sees looks like a broken project. Refreshed from the real
+attached asset via `scripts/refresh-package-manifests.py`. That step is manual and no
+workflow runs it, which is how it drifted; the file now says so at the top instead of
+implying it is automatic.
+
+**Architecture.** The `.dmg` is built on `macos-latest`, which is an **arm64** image (the
+v2.18.0 run resolved Python to `aarch64-apple-darwin`), and the spec passes
+`target_arch=None` — host architecture, *not* `universal2`, whatever the comment there
+claimed. The shipped `.dmg` has no `x86_64` slice and cannot launch on an Intel Mac, yet
+the cask had no architecture constraint and `docs/macos-install.md` explicitly promised
+"Apple Silicon or Intel".
+
+The cask now declares `depends_on arch: :arm64` so Homebrew refuses cleanly instead of
+installing something that silently fails to start, and both the cask caveats and the macOS
+guide route Intel users to `pipx install yazses`, which is architecture independent.
+
+`universal2` is not reachable by editing that one value: PyInstaller emits a universal
+binary only when every bundled native dependency is universal, and `ctranslate2` publishes
+separate arm64 and x86_64 macOS wheels. Real Intel coverage needs a second CI job on an
+Intel runner, and GitHub now offers those only as `-large`/`-intel` labels, which are
+billed even for public repositories. That is a spend decision, so it is written down in
+`packaging/README.md` rather than quietly assumed.
+
 ## [2.18.0] - 2026-08-13
 
 ### Changed — Qt is the `desktop` extra now, and a headless install is ~650 MB lighter

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ yazses verify               # speak once and prove the whole pipeline works
 
 Release the key — YazSes transcribes and acts. On a modern laptop CPU that is a median of **1.6 s** with the default `base.en` model, or **0.9 s** with `tiny.en` ([measured](docs/benchmarks.md)).
 
-> **First time on macOS?** v0 builds are unsigned: right-click the app → Open (Gatekeeper), then grant Accessibility + Microphone when prompted.
+> **First time on macOS?** The `.app` is still unsigned: right-click the app → Open (Gatekeeper), then grant Accessibility + Microphone when prompted.
 >
 > **First time on Windows?** If SmartScreen warns you, click **More info → Run anyway**.
 
@@ -418,12 +418,21 @@ yazses doctor                           # says if anything is still missing
 ### macOS
 
 ```sh
-# pipx (Python ≥ 3.11)
+# Homebrew — Apple Silicon only (see below)
+brew tap MSKazemi/yazses
+brew install --cask yazses
+
+# pipx (Python ≥ 3.11) — works on Apple Silicon and Intel
 pipx install yazses
 
-# App bundle (.dmg) — unsigned developer preview
+# App bundle (.dmg) — unsigned developer preview, Apple Silicon only
 # https://github.com/MSKazemi/yazses/releases/latest
 ```
+
+> **On an Intel Mac, use pipx.** The `.dmg` is built host-arch on GitHub's arm64
+> `macos-latest` runner and carries no `x86_64` slice, so it cannot launch on Intel;
+> the cask declares `arch: :arm64` and refuses rather than installing a broken app.
+> Details in [docs/macos-install.md](docs/macos-install.md).
 
 ### Windows
 

--- a/docs/macos-install.md
+++ b/docs/macos-install.md
@@ -13,17 +13,64 @@ description: "Install YazSes on macOS for private, on-device dictation: pipx ins
 
 ## Requirements
 
-- macOS 11 (Big Sur) or later, Apple Silicon or Intel
+- macOS 11 (Big Sur) or later
+- **Apple Silicon (M1 or later) for the `.dmg`** — see the note below if you
+  are on an Intel Mac
 - ~250 MB free disk for the app + the Whisper model on first download
 - A microphone
 
+### Which Mac do I have?
+
+Apple menu → **About This Mac**. If *Chip* says **Apple M1/M2/M3/M4**, use the
+`.dmg`. If *Processor* says **Intel**, use the pipx route below.
+
+Or from a terminal:
+
+```sh
+uname -m      # arm64 → Apple Silicon;  x86_64 → Intel
+```
+
 ## Install
+
+### Apple Silicon — Homebrew (recommended)
+
+```sh
+brew tap MSKazemi/yazses
+brew install --cask yazses
+```
+
+Upgrades then come with `brew upgrade --cask yazses`.
+
+### Apple Silicon — direct download
 
 1. Download `YazSes-<version>.dmg` from the
    [Releases](https://github.com/MSKazemi/yazses/releases) page.
 2. Open the `.dmg`. Drag **YazSes.app** into the **Applications** folder shown
    in the Finder window.
 3. Eject the `.dmg`.
+
+### Intel Macs — install from PyPI
+
+The `.dmg` is built on GitHub's `macos-latest` runner, which is an Apple
+Silicon image, and it is **not** a universal binary — it carries no `x86_64`
+slice and will not launch on an Intel Mac. The Homebrew cask declares
+`depends_on arch: :arm64`, so `brew install --cask yazses` refuses cleanly on
+Intel rather than installing something that cannot start.
+
+Install from PyPI instead, which is architecture independent:
+
+```sh
+pipx install yazses
+yazses quickstart
+```
+
+You get the same daemon and CLI; what you do not get is the `.app` bundle and
+its tray icon. Everything below about Accessibility and Microphone permissions
+still applies — grant them to your **terminal** app instead of to YazSes.app.
+
+> An Intel `.dmg` would need a second CI job on an Intel runner. GitHub now
+> offers those only as `-large`/`-intel` labels, which are billed even for
+> public repositories, so it is a spend decision rather than an oversight.
 
 ## First launch — Gatekeeper bypass
 
@@ -119,6 +166,17 @@ Run `--cli doctor` to see what YazSes is detecting.
 heuristics. Build from source (`scripts/build-macos.sh`) if you prefer.
 
 ## Uninstall
+
+If you installed with Homebrew, that route also removes the app, stops the
+launchd agent, and (with `--zap`) clears the support files:
+
+```sh
+brew uninstall --zap --cask yazses
+```
+
+Installed from PyPI? `pipx uninstall yazses`.
+
+For a manual `.dmg` install:
 
 ```sh
 launchctl bootout gui/$(id -u)/com.yazses.daemon 2>/dev/null || true

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -35,7 +35,8 @@ sudo apt remove yazses           # the APT / .deb path
 sudo snap remove yazses          # the Snap path
 ```
 
-On **macOS**, drag `YazSes.app` to the Trash if you used the `.dmg`.
+On **macOS**, run `brew uninstall --zap --cask yazses` if you installed from the
+Homebrew tap, or drag `YazSes.app` to the Trash if you used the `.dmg`.
 On **Windows**, use *Settings → Apps → Installed apps → YazSes → Uninstall*.
 
 ## 3. Remove your data

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -133,9 +133,17 @@ They are deliberately committed as *unshipped* rather than published blind — t
 reason this file has a status table is that this repo already had three manifests that
 looked finished and installed nobody.
 
-⚠️ `scoop/yazses.json` deliberately has **no `autoupdate.hash`**. Releases publish no
-`SHA256SUMS` asset, so pointing at one would 404 and silently break every future update;
-with the key absent, Scoop downloads the new installer and computes the digest itself.
+⚠️ `scoop/yazses.json` deliberately has **no `autoupdate.hash`**. When it was written,
+releases published no `SHA256SUMS` asset, so pointing at one would 404 and silently break
+every future update; with the key absent, Scoop downloads the new installer and computes
+the digest itself.
+
+**That premise changed on 2026-08-13.** PR #262 added `.github/workflows/checksums.yml`,
+which attaches a `SHA256SUMS.txt` to every release. So `autoupdate.hash` *could* now point
+at it — but the manifest has not been changed, deliberately: the first release carrying
+that asset should be observed before a future auto-update is made to depend on it, and
+nothing here has been installed on a real Windows machine yet. Revisit alongside
+[#79](https://github.com/MSKazemi/yazses/issues/79).
 
 ### Nix
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,7 +15,7 @@ registry. Every channel below was checked live on 2026-08-11:
 | Snap Store | ✅ live | `../snap/` | incl. arm64 |
 | APT repo | ✅ live | `../scripts/update-apt-repo.sh` | signed |
 | GitHub Releases | ✅ live | — | `.dmg`, `.exe`, `.deb` |
-| **Homebrew** | ❌ **404** | `homebrew/yazses.rb` | cask is **current (2.17.0, real sha)** — needs a tap repo ([#6](https://github.com/MSKazemi/yazses/issues/6)) |
+| **Homebrew** | ⚠ see below | `homebrew/yazses.rb` | cask refreshed to **2.18.0 (real sha)** and now declares `arch: :arm64` — tap status in the macOS section below ([#6](https://github.com/MSKazemi/yazses/issues/6)) |
 | **winget** | ❌ **404** | `winget/…/2.18.0/` | manifests are **current (2.18.0, real sha)** — needs a PR to `microsoft/winget-pkgs` ([#78](https://github.com/MSKazemi/yazses/issues/78)) |
 | **AUR** | ❌ **404** | `arch/PKGBUILD` | ⚠ stale at `pkgver=0.4.0`, `sha256sums=SKIP` ([#67](https://github.com/MSKazemi/yazses/issues/67)) |
 | **Flathub** | ❌ not found | — | nothing built yet ([#45](https://github.com/MSKazemi/yazses/issues/45)) |
@@ -36,6 +36,42 @@ Rust binary** distribution. The releases they point at (`v1.0.0`, `v1.0.0-dev.1`
 **never published** — `gh release view v1.0.0` returns *release not found* — and their
 checksums are still `PLACEHOLDER_…`. They are marked at the top of each file. **The
 canonical cask is `homebrew/yazses.rb`.**
+
+### macOS: the .dmg is Apple Silicon only
+
+Audited 2026-08-13, and this is the single most important fact about the macOS
+channel because the docs previously promised the opposite.
+
+`build-macos.yml` runs on `macos-latest`. That label is an **arm64** image — the
+v2.18.0 build resolved its Python to `aarch64-apple-darwin`, confirmed from the job
+log. `packaging/macos/yazses.spec` passes `target_arch=None`, which PyInstaller reads
+as *host architecture*, not `universal2` despite what the comment there used to say.
+So `YazSes-2.18.0.dmg` contains **no x86_64 slice and cannot launch on an Intel Mac.**
+
+`universal2` is not reachable by changing that one value. PyInstaller can only emit a
+universal binary when every bundled native dependency is itself universal, and
+`ctranslate2` (via `faster-whisper`) publishes separate arm64 and x86_64 macOS wheels.
+
+Intel coverage therefore needs a **second CI job on an Intel runner**. GitHub retired
+the free Intel image; Intel is now only `-large`/`-intel` labels, which are billed
+**even for public repositories**. That is a spend decision, so it is documented rather
+than assumed. Until it is made:
+
+- the cask declares `depends_on arch: :arm64`, so Homebrew refuses cleanly on Intel
+  instead of installing an app that cannot start;
+- `docs/macos-install.md` routes Intel users to `pipx install yazses`, which is
+  architecture independent.
+
+⚠ **Three open issues invite contributors to test on hardware that cannot work.**
+[#216](https://github.com/MSKazemi/yazses/issues/216) ("Test YazSes on macOS (Intel)")
+in particular asks someone to test a `.dmg` now known to be arm64-only;
+[#24](https://github.com/MSKazemi/yazses/issues/24) and
+[#182](https://github.com/MSKazemi/yazses/issues/182) should say which chip they mean.
+They need rewording before anyone spends an evening on them.
+
+⚠ **No human has confirmed the `.dmg` launches at all**, on either architecture. A
+71 MB artefact existing is not evidence that it runs — this repo has already shipped a
+Windows `.exe` across several releases that never started a daemon.
 
 ### Windows: Scoop and Chocolatey
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -69,7 +69,24 @@ channel because the docs previously promised the opposite.
 v2.18.0 build resolved its Python to `aarch64-apple-darwin`, confirmed from the job
 log. `packaging/macos/yazses.spec` passes `target_arch=None`, which PyInstaller reads
 as *host architecture*, not `universal2` despite what the comment there used to say.
-So `YazSes-2.18.0.dmg` contains **no x86_64 slice and cannot launch on an Intel Mac.**
+So the `.dmg` contains **no x86_64 slice and cannot launch on an Intel Mac.**
+
+This was **verified against the artefact**, not only inferred from the runner. The
+`.dmg` that CI built for PR #263 was decompressed on Linux (UDIF/`koly` trailer → blkx
+block table → zlib chunks; no macOS tooling involved) and every Mach-O header in the
+image inspected:
+
+```
+Mach-O slices found, by CPU type: {'arm64': 122}
+MH_EXECUTE (main binaries):      1, arm64
+universal/fat headers (0xCAFEBABE): 0
+```
+
+122 arm64 slices, **zero x86_64, zero universal headers**. The same pass read the
+bundle's `Info.plist` straight out of the image and confirmed the version fix landed:
+`CFBundleShortVersionString` and `CFBundleVersion` both `2.18.0` (they were the literal
+`0.1.2` before), and `LSMinimumSystemVersion` `11.0`, matching the cask's
+`depends_on macos: ">= :big_sur"`.
 
 `universal2` is not reachable by changing that one value. PyInstaller can only emit a
 universal binary when every bundled native dependency is itself universal, and

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,7 +15,7 @@ registry. Every channel below was checked live on 2026-08-11:
 | Snap Store | ✅ live | `../snap/` | incl. arm64 |
 | APT repo | ✅ live | `../scripts/update-apt-repo.sh` | signed |
 | GitHub Releases | ✅ live | — | `.dmg`, `.exe`, `.deb` |
-| **Homebrew** | ⚠ see below | `homebrew/yazses.rb` | cask refreshed to **2.18.0 (real sha)** and now declares `arch: :arm64` — tap status in the macOS section below ([#6](https://github.com/MSKazemi/yazses/issues/6)) |
+| **Homebrew** | ✅ live | `homebrew/yazses.rb` | tap published 2026-08-13 at [MSKazemi/homebrew-yazses](https://github.com/MSKazemi/homebrew-yazses); cask at **2.18.0 (real sha)**, **arm64 only** — see the macOS section ([#6](https://github.com/MSKazemi/yazses/issues/6)) |
 | **winget** | ❌ **404** | `winget/…/2.18.0/` | manifests are **current (2.18.0, real sha)** — needs a PR to `microsoft/winget-pkgs` ([#78](https://github.com/MSKazemi/yazses/issues/78)) |
 | **AUR** | ❌ **404** | `arch/PKGBUILD` | ⚠ stale at `pkgver=0.4.0`, `sha256sums=SKIP` ([#67](https://github.com/MSKazemi/yazses/issues/67)) |
 | **Flathub** | ❌ not found | — | nothing built yet ([#45](https://github.com/MSKazemi/yazses/issues/45)) |
@@ -36,6 +36,29 @@ Rust binary** distribution. The releases they point at (`v1.0.0`, `v1.0.0-dev.1`
 **never published** — `gh release view v1.0.0` returns *release not found* — and their
 checksums are still `PLACEHOLDER_…`. They are marked at the top of each file. **The
 canonical cask is `homebrew/yazses.rb`.**
+
+### Homebrew tap
+
+Published 2026-08-13 at **[MSKazemi/homebrew-yazses](https://github.com/MSKazemi/homebrew-yazses)**,
+which is what makes `brew tap MSKazemi/yazses && brew install --cask yazses` resolve. The
+repository name must stay `homebrew-yazses` — Homebrew derives the tap name from it.
+
+`Casks/yazses.rb` there is **byte-identical** to `homebrew/yazses.rb` here, which stays the
+source of truth. After each release, refresh the checksum and copy it across:
+
+```sh
+python scripts/refresh-package-manifests.py --version <x.y.z>
+cp packaging/homebrew/yazses.rb <tap>/Casks/yazses.rb   # then commit + push the tap
+```
+
+Verified at publication: the tap is public, `Casks/yazses.rb` serves HTTP 200 and matches
+the source byte for byte, and the `.dmg` URL the cask points at resolves on the v2.18.0
+release.
+
+⚠ **Not verified: that `brew install --cask yazses` actually completes.** Casks only
+install on macOS and the authoring machine is Linux, so the end-to-end run is owed by
+whoever first has a Mac in hand. What is proven is that every input Homebrew reads is
+present, well-formed and correctly hashed.
 
 ### macOS: the .dmg is Apple Silicon only
 

--- a/packaging/homebrew/yazses.rb
+++ b/packaging/homebrew/yazses.rb
@@ -1,10 +1,23 @@
-# THIS is the canonical Homebrew artefact for YazSes. The two other .rb files in
-# this directory (`yazses-formula.rb`, `yazses-v1.rb`) describe an abandoned v1.0
-# Rust binary distribution whose releases were never published — see the header
-# comments in those files. Do not publish them.
+# The canonical Homebrew cask for YazSes.
 #
-# The sha256 below was computed from the released asset itself:
-#   gh release download v2.17.0 -p 'YazSes-2.17.0.dmg' && sha256sum YazSes-2.17.0.dmg
+# Source of truth: packaging/homebrew/yazses.rb in MSKazemi/yazses.
+# Published copy:  Casks/yazses.rb in MSKazemi/homebrew-yazses (the tap users
+# actually tap). The two are byte-identical; edit the source and copy it over,
+# never the other way round.
+#
+# Two sibling files in packaging/homebrew/ -- `yazses-formula.rb` and
+# `yazses-v1.rb` -- describe an abandoned v1.0 Rust binary distribution whose
+# releases were never published, and still carry PLACEHOLDER checksums. They are
+# kept only as history. Do not publish them.
+#
+# Do not hand-edit the version or sha256 below. Regenerate them from the assets
+# actually attached to the tag:
+#   python scripts/refresh-package-manifests.py --version <x.y.z>
+#
+# This is still a manual post-release step -- no workflow runs it, which is how
+# this file sat at v2.17.0 while v2.18.0 was the current release. A wrong hash is
+# worse than no cask: Homebrew refuses the download, so the first thing a new
+# user sees is a failure that looks like the project is broken.
 cask "yazses" do
   version "2.18.0"
   sha256 "ef33405e19eb4fbe7c1ba1ffc02554d432288517354963cbe886cc7e41880370"
@@ -23,6 +36,17 @@ cask "yazses" do
   # Matches LSMinimumSystemVersion "11.0" declared by the app bundle itself in
   # packaging/macos/yazses.spec — keep the two in step.
   depends_on macos: ">= :big_sur"
+
+  # Apple Silicon only, and this is a statement of fact about the artefact, not
+  # a preference. The .dmg is built by .github/workflows/build-macos.yml on
+  # macos-latest, which is an arm64 image, and packaging/macos/yazses.spec
+  # passes target_arch=None (host arch). So the bundled Mach-O has no x86_64
+  # slice and will not launch on an Intel Mac.
+  #
+  # Without this line Homebrew installs it anyway and the user gets a silent
+  # failure to launch. With it they get a clean, accurate refusal and the
+  # caveats below point them at the install route that does work on Intel.
+  depends_on arch: :arm64
 
   app "YazSes.app"
 
@@ -51,5 +75,15 @@ cask "yazses" do
 
     This is an unsigned developer preview. If macOS refuses to launch the
     app, right-click YazSes.app and choose Open the first time.
+
+    Because it is unsigned, macOS treats the app as a new identity whenever
+    its hash changes, so you may have to re-grant Accessibility after an
+    upgrade.
+
+    On an Intel Mac this cask will refuse to install: the .dmg is built for
+    Apple Silicon only. Install from PyPI instead, which is architecture
+    independent:
+
+        pipx install yazses && yazses quickstart
   EOS
 end

--- a/packaging/macos/yazses.spec
+++ b/packaging/macos/yazses.spec
@@ -14,11 +14,22 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 REPO = Path(SPECPATH).resolve().parents[1]
 ENTRY = str(REPO / "src" / "yazses" / "__main__.py")
 ICON = REPO / "assets" / "yazses.icns"
+
+# Read the version from pyproject rather than restating it here. These two used
+# to be separate literals, and the copy in this file was never updated after
+# v0.1.2 -- so every .dmg from v0.1.3 to v2.18.0 shipped an .app that told macOS
+# it was version 0.1.2. Finder's Get Info, `mdls`, and any updater that compares
+# CFBundleShortVersionString all read that number, so a genuine upgrade looked
+# like a downgrade. Derive it and the drift cannot come back.
+VERSION = tomllib.loads(
+    (REPO / "pyproject.toml").read_text(encoding="utf-8")
+)["project"]["version"]
 
 block_cipher = None
 
@@ -72,7 +83,21 @@ exe = EXE(
     upx=False,
     console=False,         # --windowed
     disable_windowed_traceback=False,
-    target_arch=None,      # universal2 in CI; fallback to host arch locally
+    # Host arch only -- NOT universal2, whatever an earlier comment here claimed.
+    # PyInstaller reads target_arch=None as "build for the machine you are on",
+    # and CI builds on macos-latest, which is Apple Silicon (the v2.18.0 run
+    # resolved its Python to aarch64-apple-darwin). So the released .dmg is
+    # arm64-only and will not launch on an Intel Mac.
+    #
+    # universal2 is not reachable by flipping this value: PyInstaller can only
+    # emit a universal2 binary when *every* bundled native dependency is itself
+    # universal2, and ctranslate2 (via faster-whisper) publishes separate
+    # arm64 and x86_64 macOS wheels. Intel coverage needs a second CI job on an
+    # Intel runner, and those are `-large`/`-intel` labels, which GitHub bills
+    # even for public repositories. That is a spend decision, so it is filed
+    # rather than assumed -- see docs/macos-install.md for what Intel users do
+    # in the meantime (pipx install yazses).
+    target_arch=None,
     codesign_identity=None,  # signed in a separate step (deferred to public beta)
     entitlements_file=None,
 )
@@ -98,8 +123,8 @@ app = BUNDLE(
         "CFBundleName": "YazSes",
         "CFBundleDisplayName": "YazSes",
         "CFBundleIdentifier": "com.yazses.app",
-        "CFBundleVersion": "0.1.2",
-        "CFBundleShortVersionString": "0.1.2",
+        "CFBundleVersion": VERSION,
+        "CFBundleShortVersionString": VERSION,
         "CFBundleExecutable": "YazSes",
 
         # No Dock icon — tray-only app.

--- a/tests/test_packaging_macos.py
+++ b/tests/test_packaging_macos.py
@@ -1,0 +1,214 @@
+"""Guards on the macOS packaging artefacts.
+
+These files are never exercised by the test suite the way `src/` is -- the .app is
+built by PyInstaller on a macOS runner and the cask is consumed by Homebrew, so
+neither is imported here and both drifted silently for a long time:
+
+* `packaging/macos/yazses.spec` hardcoded ``CFBundleVersion = "0.1.2"``. Every
+  .dmg from v0.1.3 through v2.18.0 shipped an .app that told macOS it was
+  version 0.1.2, so an upgrade read as a downgrade.
+* `packaging/homebrew/yazses.rb` sat at v2.17.0 with v2.17.0's checksum while
+  v2.18.0 was the current release, and carried no architecture constraint even
+  though the .dmg is arm64-only.
+
+The checks below are deliberately offline and content-based: they parse the two
+files as text/TOML and never download an asset, so they are cheap enough to run
+in ordinary CI on every platform.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SPEC = REPO / "packaging" / "macos" / "yazses.spec"
+CASK = REPO / "packaging" / "homebrew" / "yazses.rb"
+
+
+@pytest.fixture(scope="module")
+def spec_text() -> str:
+    return SPEC.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def cask_text() -> str:
+    return CASK.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def project_version() -> str:
+    data = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+# --------------------------------------------------------------------------
+# yazses.spec
+# --------------------------------------------------------------------------
+
+
+def test_spec_derives_version_from_pyproject(spec_text: str) -> None:
+    """CFBundle* must be derived, never a literal.
+
+    A literal is what produced the 0.1.2 bug: it cannot be caught by reading the
+    spec, only by inspecting a built .app on a Mac, which nobody does.
+    """
+    assert '"CFBundleVersion": VERSION' in spec_text
+    assert '"CFBundleShortVersionString": VERSION' in spec_text
+
+    # And the derivation actually reads pyproject.
+    assert "tomllib" in spec_text
+    assert 'pyproject.toml' in spec_text
+
+
+def test_spec_version_expression_evaluates_to_project_version(
+    spec_text: str, project_version: str
+) -> None:
+    """Execute the spec's own version lookup and compare to pyproject.
+
+    Guards against the derivation being present but pointed at the wrong key --
+    e.g. ``["tool"]["poetry"]["version"]`` on a PEP 621 project.
+    """
+    match = re.search(
+        r"^VERSION = (tomllib\.loads\(.*?\))\[.*?\]$",
+        spec_text,
+        re.M | re.S,
+    )
+    assert match is not None, "no recognisable VERSION = tomllib.loads(...) assignment"
+
+    namespace: dict[str, object] = {"tomllib": tomllib, "REPO": REPO}
+    exec(f"VERSION = {match.group(0).split('=', 1)[1].strip()}", namespace)  # noqa: S102
+    assert namespace["VERSION"] == project_version
+
+
+def test_spec_target_arch_and_cask_arch_agree(
+    spec_text: str, cask_text: str
+) -> None:
+    """The build's architecture and the cask's `depends_on arch:` are one fact.
+
+    Asserted against the actual ``target_arch`` value rather than the surrounding
+    prose, so the two can only ever move together:
+
+    * ``target_arch=None`` -- host arch. CI's host is the arm64 ``macos-latest``
+      image, so the cask must restrict to ``:arm64``.
+    * ``target_arch="universal2"`` -- both slices present, so the cask must drop
+      the restriction. (Reaching this also requires universal2 wheels for every
+      native dependency; ``ctranslate2`` ships separate arm64/x86_64 wheels, so
+      flipping the value alone will fail the build, not fix Intel.)
+
+    Whoever pays for an Intel runner will land here, and the failure message is
+    the checklist for what else has to change.
+    """
+    match = re.search(r"^\s*target_arch=([^,]+),", spec_text, re.M)
+    assert match is not None, "no target_arch= in the EXE() block"
+    target_arch = match.group(1).strip()
+
+    cask_is_arm64_only = bool(
+        re.search(r"^\s*depends_on\s+arch:\s*:arm64", cask_text, re.M)
+    )
+
+    if target_arch == "None":
+        assert cask_is_arm64_only, (
+            "yazses.spec builds host-arch (target_arch=None) on the arm64 "
+            "macos-latest runner, so the .dmg has no x86_64 slice, but the cask "
+            "does not declare `depends_on arch: :arm64`. Intel users would "
+            "install an app that cannot launch."
+        )
+    elif target_arch.strip("\"'") == "universal2":
+        assert not cask_is_arm64_only, (
+            "yazses.spec now targets universal2, so the cask's "
+            "`depends_on arch: :arm64` wrongly locks Intel users out. Also "
+            "update docs/macos-install.md, which currently sends them to pipx."
+        )
+    else:
+        pytest.fail(
+            f"unrecognised target_arch={target_arch!r}; teach this test what it "
+            "means for the cask's architecture constraint"
+        )
+
+
+def test_spec_minimum_system_version_matches_cask(
+    spec_text: str, cask_text: str
+) -> None:
+    """LSMinimumSystemVersion and `depends_on macos:` must agree.
+
+    The cask already carried a comment asking a human to keep these in step;
+    this is that comment made enforceable.
+    """
+    spec_min = re.search(r'"LSMinimumSystemVersion":\s*"([\d.]+)"', spec_text)
+    assert spec_min is not None
+    cask_min = re.search(r"depends_on\s+macos:\s*\">=\s*:(\w+)\"", cask_text)
+    assert cask_min is not None
+
+    macos_names = {"11.0": "big_sur", "12.0": "monterey", "13.0": "ventura"}
+    expected = macos_names.get(spec_min.group(1))
+    assert expected is not None, (
+        f"unmapped LSMinimumSystemVersion {spec_min.group(1)!r}; extend macos_names"
+    )
+    assert cask_min.group(1) == expected
+
+
+# --------------------------------------------------------------------------
+# yazses.rb (the Homebrew cask)
+# --------------------------------------------------------------------------
+
+
+def test_cask_sha256_is_a_real_digest(cask_text: str) -> None:
+    """No PLACEHOLDER_… checksums.
+
+    Two sibling .rb files in this directory still carry placeholders; they are
+    kept only as history and must never be what ships.
+    """
+    match = re.search(r'^\s*sha256\s+"([^"]+)"', cask_text, re.M)
+    assert match is not None
+    digest = match.group(1)
+    assert re.fullmatch(r"[0-9a-f]{64}", digest), (
+        f"cask sha256 is not a 64-char hex digest: {digest!r}"
+    )
+
+
+def test_cask_url_interpolates_version(cask_text: str) -> None:
+    """The URL must be built from `version`, so the two cannot diverge."""
+    match = re.search(r"^\s*url\s+\"([^\"]+)\"", cask_text, re.M)
+    assert match is not None
+    url = match.group(1)
+    assert "#{version}" in url, f"cask url hardcodes a version: {url!r}"
+
+
+def test_cask_declares_arm64_only(cask_text: str) -> None:
+    """The .dmg has no x86_64 slice, so the cask must refuse on Intel.
+
+    Without this, `brew install --cask yazses` on an Intel Mac succeeds and then
+    the app silently fails to launch. See packaging/README.md.
+    """
+    assert re.search(r"^\s*depends_on\s+arch:\s*:arm64", cask_text, re.M), (
+        "cask must declare `depends_on arch: :arm64` while the .dmg is built "
+        "host-arch on the arm64 macos-latest runner"
+    )
+
+
+def test_cask_points_intel_users_somewhere_that_works(cask_text: str) -> None:
+    """Refusing to install is only half an answer; give them the working route."""
+    caveats = cask_text.split("caveats", 1)
+    assert len(caveats) == 2, "cask has no caveats block"
+    assert "pipx install yazses" in caveats[1]
+
+
+def test_only_one_publishable_cask(cask_text: str) -> None:
+    """The two v1.0 Rust-era .rb files must stay unpublishable.
+
+    They describe releases that were never cut and still hold placeholder
+    checksums; publishing one would 404 for every user.
+    """
+    for stale in ("yazses-formula.rb", "yazses-v1.rb"):
+        path = CASK.parent / stale
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        assert "PLACEHOLDER" in text, (
+            f"{stale} no longer looks like an abandoned artefact -- if it became "
+            "real, update this test and packaging/README.md"
+        )


### PR DESCRIPTION
Started as "make YazSes installable on a Mac" and turned up three defects that had all been invisible for the same reason: verifying them needs either a Mac or a checksum, and neither was ever in the loop.

## What was wrong

**1. Every `.app` since v0.1.3 reported version 0.1.2.**
`packaging/macos/yazses.spec` set `CFBundleVersion`/`CFBundleShortVersionString` as string literals, last touched at v0.1.2. Finder's *Get Info*, `mdls`, and any version comparison read that number — so a genuine upgrade looked like a downgrade. Now derived from `pyproject.toml`.

**2. The Homebrew cask was a release behind.**
Pinned `2.17.0` with that release's sha256 while `2.18.0` was current. Homebrew verifies the digest, so this isn't cosmetic lag — the download is refused and a new user's first impression is a broken project. Refreshed from the real attached asset. The refresh is a manual post-release step that no workflow runs, which is exactly how it drifted; the file now says so instead of implying automation.

**3. The `.dmg` cannot launch on an Intel Mac, and everything claimed otherwise.**
`build-macos.yml` runs on `macos-latest` — an **arm64** image; the v2.18.0 job resolved its Python to `aarch64-apple-darwin` (confirmed from the job log). The spec passes `target_arch=None`, which PyInstaller reads as *host arch*, **not** `universal2` despite the comment there claiming it. So the bundle has no `x86_64` slice — yet the cask had no arch constraint and `docs/macos-install.md` promised "Apple Silicon or Intel".

## What changed

- Cask declares `depends_on arch: :arm64` → Homebrew refuses cleanly instead of installing an app that silently never starts.
- Cask caveats, `docs/macos-install.md` and `README.md` route Intel users to `pipx install yazses`, which is architecture independent.
- **Homebrew tap published** at [MSKazemi/homebrew-yazses](https://github.com/MSKazemi/homebrew-yazses) — `brew install yazses` had 404'd since v1 because the cask lived in `packaging/` and never reached a registry. Closes #6.
- `tests/test_packaging_macos.py` — the first test over `packaging/` at all. Offline and content-based (parses the spec and cask, downloads nothing), and ties the build's architecture to the cask's constraint so the two can only move together.
- winget 2.18.0 manifests, which `--check` reported missing.

## Why universal2 isn't the fix

PyInstaller emits a universal binary only when *every* bundled native dependency is universal, and `ctranslate2` (via `faster-whisper`) publishes separate arm64 and x86_64 macOS wheels. Real Intel coverage needs a second CI job on an Intel runner — and GitHub now offers those only as `-large`/`-intel` labels, which are **billed even for public repositories**. That's a spend decision, so it's written down in `packaging/README.md` rather than quietly assumed.

## Verification

- `pytest`: 2972 passed, 15 skipped
- `ruff check src tests scripts`: clean
- `mypy src`: 11 pre-existing `import-not-found` errors for optional backends (PySide6 etc.), unchanged — no `src/` file is touched by this PR
- Both regressions confirmed to **fail** the new tests before the fix (red-green)
- `refresh-package-manifests.py --version 2.18.0 --check`: every manifest matches the released assets
- Tap: public, `Casks/yazses.rb` serves 200 and is byte-identical to the source, `.dmg` URL resolves

## Still owed — needs a Mac

- **Nobody has confirmed the `.dmg` launches**, on either architecture. A 71 MB artefact existing is not evidence it runs; this repo already shipped a Windows `.exe` across several releases that never started a daemon.
- **`brew install --cask yazses` has never been run** — casks install only on macOS, and this was authored on Linux. Every input Homebrew reads is verified; the run itself is not.
- Issues #24, #182 and #216 invite contributors to test on macOS. **#216 asks for Intel testing of a `.dmg` now known to be arm64-only** and should be reworded before someone spends an evening on it.