### PR TITLE
fix(ci): the checksum job could never see a release asset

### DIFF
--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -34,6 +34,12 @@ jobs:
       contents: write # uploads SHA256SUMS.txt onto the existing Release
     env:
       GH_TOKEN: ${{ github.token }}
+      # This job deliberately does not check out the repository -- it only needs
+      # the release assets. But without a checkout `gh` has no git remote to infer
+      # the repo from, so every `gh release` call fails. GH_REPO supplies it
+      # explicitly. Omitting this made the wait loop below poll an empty asset
+      # list for its full 40-minute deadline instead of failing.
+      GH_REPO: ${{ github.repository }}
       TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
     steps:
       - name: Wait for platform builds to attach their assets
@@ -46,8 +52,23 @@ jobs:
         run: |
           set -euo pipefail
           deadline=$(( SECONDS + 2400 ))   # 40 minutes
+          fails=0
           while (( SECONDS < deadline )); do
-            names=$(gh release view "$TAG" --json assets -q '.assets[].name' || true)
+            # A failed query and a release with no assets yet are NOT the same
+            # thing. Swallowing both with `|| true` made a misconfiguration look
+            # exactly like a slow build. Tolerate a couple of transient errors,
+            # then fail loudly rather than waiting out the deadline.
+            if ! names=$(gh release view "$TAG" --json assets -q '.assets[].name'); then
+              fails=$(( fails + 1 ))
+              echo "::warning::could not query release $TAG (attempt $fails)"
+              if (( fails >= 3 )); then
+                echo "::error::gh release view failed 3x for $TAG -- aborting."
+                exit 1
+              fi
+              sleep 20
+              continue
+            fi
+            fails=0
             have_deb=$(grep -c '\.deb$'  <<<"$names" || true)
             have_dmg=$(grep -c '\.dmg$'  <<<"$names" || true)
             have_exe=$(grep -c '\.exe$'  <<<"$names" || true)


### PR DESCRIPTION
Follow-up to #262. The workflow that PR added **cannot work as merged** — found by actually dispatching it against `v2.18.0`, not by reading it.

## Cause

The job deliberately skips `actions/checkout` (it needs the release assets, not the source). But without a checkout `gh` has no git remote to infer the repository from, and `GH_REPO` was not set either — so **every `gh release view` call failed immediately**.

`|| true` then swallowed that failure, making an empty asset list indistinguishable from a build still uploading. The wait loop polled nothing for its full 40-minute deadline; the run had to be cancelled by hand.

## Fix

- Set `GH_REPO: ${{ github.repository }}` — the actual cause.
- Stop hiding the symptom: a *failed query* and a *release with no assets yet* are different events. Tolerate three transient errors, then abort with an error annotation rather than waiting out the deadline.

## Why the original review missed it

`bash -n` and a YAML parse both **passed** on the broken version — the defect was in the runtime environment, not the syntax. Nothing short of running it would have caught this, which is the point worth keeping.