### PR TITLE
fix(release): v2.18.1 published half a release — PyPI and the .deb never shipped

### DIFF
--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -6,8 +6,8 @@ $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   packageName    = 'yazses'
   fileType       = 'exe'
-  url64bit       = 'https://github.com/MSKazemi/yazses/releases/download/v2.18.0/YazSes-2.18.0-windows-x64.exe'
-  checksum64     = 'd5d78e9db771e5c808a240624b9076444067e76922dab109e1e72be0f757646a'
+  url64bit       = 'https://github.com/MSKazemi/yazses/releases/download/v2.18.1/YazSes-2.18.1-windows-x64.exe'
+  checksum64     = '11cd6cf190c9f13f5bdb21a6482f9bec8509e55df2cf1726979c45f7157d3fe2'
   checksumType64 = 'sha256'
   # Inno Setup: /VERYSILENT so unattended installs do not stall on the wizard.
   silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'

--- a/packaging/chocolatey/yazses.nuspec
+++ b/packaging/chocolatey/yazses.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>yazses</id>
-    <version>2.18.0</version>
+    <version>2.18.1</version>
     <packageSourceUrl>https://github.com/MSKazemi/yazses/tree/main/packaging/chocolatey</packageSourceUrl>
     <owners>MSKazemi</owners>
     <title>YazSes (Install)</title>
@@ -35,7 +35,7 @@ a whole meeting into a speaker-labelled transcript with locally generated minute
 * The Windows build is **not code-signed yet**, so SmartScreen may warn on first launch.
 * Installs per-user (no administrator rights required).
 ]]></description>
-    <releaseNotes>https://github.com/MSKazemi/yazses/releases/tag/v2.18.0</releaseNotes>
+    <releaseNotes>https://github.com/MSKazemi/yazses/releases/tag/v2.18.1</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/homebrew/yazses.rb
+++ b/packaging/homebrew/yazses.rb
@@ -19,8 +19,8 @@
 # worse than no cask: Homebrew refuses the download, so the first thing a new
 # user sees is a failure that looks like the project is broken.
 cask "yazses" do
-  version "2.18.0"
-  sha256 "ef33405e19eb4fbe7c1ba1ffc02554d432288517354963cbe886cc7e41880370"
+  version "2.18.1"
+  sha256 "9763a43d1400204355cf97a288538b278f04d93ef0bc13fcdc909e1fec78db38"
 
   url "https://github.com/MSKazemi/yazses/releases/download/v#{version}/YazSes-#{version}.dmg",
       verified: "github.com/MSKazemi/yazses/"

--- a/packaging/scoop/yazses.json
+++ b/packaging/scoop/yazses.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.18.0",
+    "version": "2.18.1",
     "description": "Offline voice dictation and speech-to-text - hold a key, speak, release. Runs on your own CPU with no cloud, no API key and no subscription.",
     "homepage": "https://mskazemi.com/yazses/",
     "license": "Apache-2.0",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/MSKazemi/yazses/releases/download/v2.18.0/YazSes-2.18.0-windows-x64.exe#/setup.exe",
-            "hash": "d5d78e9db771e5c808a240624b9076444067e76922dab109e1e72be0f757646a"
+            "url": "https://github.com/MSKazemi/yazses/releases/download/v2.18.1/YazSes-2.18.1-windows-x64.exe#/setup.exe",
+            "hash": "11cd6cf190c9f13f5bdb21a6482f9bec8509e55df2cf1726979c45f7157d3fe2"
         }
     },
     "innosetup": true,

--- a/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.installer.yaml
+++ b/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.18.1
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{F3E8B8A4-1B6C-4F24-9BE8-9B7E58E9C4A2}_is1'
+MinimumOSVersion: 10.0.19041.0
+ReleaseDate: 2026-08-13
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MSKazemi/yazses/releases/download/v2.18.1/YazSes-2.18.1-windows-x64.exe
+    InstallerSha256: 11CD6CF190C9F13F5BDB21A6482F9BEC8509E55DF2CF1726979C45F7157D3FE2
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.locale.en-US.yaml
+++ b/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.locale.en-US.yaml
@@ -1,0 +1,49 @@
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.18.1
+PackageLocale: en-US
+Publisher: MSKazemi
+PublisherUrl: https://github.com/MSKazemi
+PublisherSupportUrl: https://github.com/MSKazemi/yazses/issues
+Author: Mohsen Seyedkazemi Ardebili
+PackageName: YazSes
+PackageUrl: https://mskazemi.com/yazses/
+License: Apache-2.0
+LicenseUrl: https://github.com/MSKazemi/yazses/blob/main/LICENSE
+Copyright: Copyright 2026 Mohsen Seyedkazemi Ardebili
+ShortDescription: Offline voice dictation — hold a key, speak, release. No cloud, no API key, no subscription.
+Description: |-
+  YazSes is a free, open-source, offline voice dictation and speech-to-text
+  tool. Hold a key, speak, release — your words are transcribed on your own CPU
+  and typed into whatever window has focus.
+
+  Everything runs on-device with faster-whisper. There is no cloud service, no
+  API key, no account and no subscription, and no telemetry of any kind. Use it
+  when audio must not be sent to a third party — a confidential meeting, an
+  air-gapped machine, or simply a preference not to rent your own voice.
+
+  It also transcribes recordings (`yazses transcribe talk.m4a`, with optional
+  speaker labels) and can capture a whole meeting into a speaker-labelled
+  transcript with locally generated minutes.
+Moniker: yazses
+Tags:
+  - voice
+  - dictation
+  - voice-typing
+  - speech-to-text
+  - speech-recognition
+  - whisper
+  - transcription
+  - offline
+  - on-device
+  - privacy
+  - accessibility
+  - productivity
+  - open-source
+Documentations:
+  - DocumentLabel: Documentation
+    DocumentUrl: https://mskazemi.com/yazses/
+  - DocumentLabel: Windows install guide
+    DocumentUrl: https://mskazemi.com/yazses/windows-install.html
+ReleaseNotesUrl: https://github.com/MSKazemi/yazses/releases/tag/v2.18.1
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.yaml
+++ b/packaging/winget/manifests/m/MSKazemi/YazSes/2.18.1/MSKazemi.YazSes.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: MSKazemi.YazSes
+PackageVersion: 2.18.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## The situation, right now

**v2.18.1 looks shipped and is not.** The tag, the GitHub Release, the `.dmg` and the `.exe` all exist. But the Release run's `test` job failed, so `publish-pypi` and `release-linux` were **skipped**:

| | State |
|---|---|
| GitHub Release + `.dmg` + `.exe` | ✅ published |
| **PyPI** | ❌ still serves **2.18.0** |
| **`.deb` / APT repo** | ❌ never built, so APT cannot pick it up |

Anyone installing with `pipx` or `apt` is silently still on 2.18.0.

## Why it failed

The four manifest guards added a few hours earlier in #261:

```
assert '2.18.0' == '2.18.1'            scoop/yazses.json
assert '<version>2.18.1</version>'     chocolatey/yazses.nuspec
assert '2.18.1' in script              chocolatey/tools/chocolateyinstall.ps1
no winget manifest folder for 2.18.1
```

**These are good guards and they caught a real gap** — the manifests genuinely were stale. But they close a loop the release process can't satisfy in order:

> a manifest pins the **SHA256 of a built installer** → it can't be written until the tag is pushed and CI has published the asset → but the job gated on those manifests runs **before** that.

v2.18.0 was the last release to ship cleanly because the guards didn't exist yet. v2.18.1 is the first to hit the deadlock.

*(Aside: these same four tests are **skipped**, not passed, in the ordinary `Tests` workflow — `actions/checkout` fetches no tags, so `_released_version()` takes its `pytest.skip("no release tags")` branch. That's why main reads green. They only fire on tag-triggered runs.)*

## What this PR does

Unblocks the **current** release. It does not redesign the process.

The assets are attached to v2.18.1 now, so every checksum is computed from the real artefact rather than carried forward:

```
YazSes-2.18.1.dmg              9763a43d…db38
YazSes-2.18.1-windows-x64.exe  11cd6cf1…3fe2
```

- cask + winget 2.18.1 regenerated by `scripts/refresh-package-manifests.py`
- winget **locale** manifest copied forward with `PackageVersion` and the release-notes URL bumped — the script deliberately leaves it alone (prose, not checksums), but the test requires all three yaml files
- scoop, chocolatey nuspec and `chocolateyinstall.ps1` bumped to the 2.18.1 URL and digest

## Verification

- the four release-blocking gates: **49 passed**
- full suite: **3047 passed, 15 skipped**
- `ruff`: clean
- `refresh-package-manifests.py --version 2.18.1 --check`: *"every manifest matches the assets released as v2.18.1"*

## ⚠ Two things this does NOT do

1. **It does not publish anything.** Merging alone won't put 2.18.1 on PyPI — the failed Release run has to be re-run (or the job re-triggered) after this lands. That's an outward-facing publish and deliberately left as your call.
2. **It does not fix the ordering problem.** v2.18.2 will hit exactly the same deadlock. Options worth choosing between: have the release workflow refresh manifests *after* the build and commit them back; move the manifest guards out of the release gate into a post-publish check; or make `_released_version()` tolerate the in-development version. Happy to open that as a separate issue.

⚠ Touches `packaging/scoop`, `packaging/chocolatey` and `packaging/winget` — **Windows territory**, where another session has been active today. Worth a glance for collisions before merging.