### PR TITLE
docs: v2.18.0 has checksums now, so stop telling people it does not

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -49,9 +49,12 @@ run the file** — please [open an issue](https://github.com/MSKazemi/yazses/iss
 
 !!! note
 
-    `SHA256SUMS.txt` is published for releases **after v2.18.0**. For v2.18.0 and
-    earlier, compare against the hashes recorded in the package manifests under
+    `SHA256SUMS.txt` is published from **v2.18.0 onwards**. For releases older than
+    that, compare against the hashes recorded in the package manifests under
     [`packaging/`](https://github.com/MSKazemi/yazses/tree/main/packaging).
+
+    If a release is missing an artifact for your platform, that artifact's line is
+    simply absent — the checksum file lists what was actually published.
 
 ## Verify a code signature
 


### PR DESCRIPTION
Small correction to #262.

The page said `SHA256SUMS.txt` is published for releases **after v2.18.0**. That was accurate when written, and stopped being accurate the moment the workflow was backfilled onto v2.18.0 itself — it now carries a verified `SHA256SUMS.txt`.

The consequence was concrete: someone holding the current Windows installer would have been sent to the packaging manifests for a hash that is sitting on the release page.

Also documents what a *short* checksum file means. v2.18.1 shipped without a `.deb`, so its checksum file lists two artifacts rather than three — an absent line, not a tampered download.

### Verification

`SHA256SUMS.txt` on v2.18.0 was cross-checked against the independently-computed winget manifest hash:

```
SHA256SUMS.txt : d5d78e9db771e5c808a240624b9076444067e76922dab109e1e72be0f757646a
winget manifest: D5D78E9DB771E5C808A240624B9076444067E76922DAB109E1E72BE0F757646A
```

Identical. `mkdocs build --strict` passes.