### PR TITLE
ci: only the newest release has to carry every package

### DIFF
--- a/.github/workflows/release-complete.yml
+++ b/.github/workflows/release-complete.yml
@@ -122,16 +122,31 @@ jobs:
           exit 1
 
       - name: Demote an incomplete release so it is not advertised as Latest
-        # Runs only when the check above failed. A half-published release that
-        # still reads "Latest" is worse than an obviously provisional one: it
-        # sends people to a download that does not exist for their OS. Reverse
-        # with: gh release edit <tag> --prerelease=false --latest
+        # Runs only when the check above failed.
+        #
+        # ONLY the current latest release is demoted. Policy (owner, 2026-08-13):
+        # the newest version must carry every OS package; older ones need not.
+        # A superseded release being incomplete is history, not a live problem --
+        # nobody is directed to it, and rewriting old releases would misrepresent
+        # what was actually published at the time. But a half-published release
+        # that still reads "Latest" sends people to a download that does not
+        # exist for their OS, and that is worth demoting.
+        #
+        # This matters most for workflow_dispatch: running the check over an old
+        # tag should report, never rewrite.
+        #
+        # Reverse with: gh release edit <tag> --prerelease=false --latest
         if: failure()
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --prerelease
-            echo "::warning::$TAG marked pre-release because it is missing: ${MISSING:-unknown}"
-          else
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
             echo "No release exists for $TAG -- nothing to demote."
+            exit 0
           fi
+          latest=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "")
+          if [[ "$TAG" != "$latest" ]]; then
+            echo "::warning::$TAG is incomplete (${MISSING:-unknown}) but is superseded by ${latest:-unknown} -- reporting only, not demoting."
+            exit 0
+          fi
+          gh release edit "$TAG" --prerelease
+          echo "::warning::$TAG marked pre-release because it is missing: ${MISSING:-unknown}"


### PR DESCRIPTION
Refines #272 to match stated policy: **the newest version must ship a package for every OS; older versions need not.**

The gate did not know that — it would demote *any* incomplete release it was pointed at.

That is wrong for a superseded release in two ways:

- Nobody is directed to it, so an absent `.deb` is history rather than a live problem.
- Flipping an old release to pre-release **misrepresents what was actually published at the time**.

It matters most for `workflow_dispatch`: checking an old tag should report, never rewrite.

## Change

Demote only when the tag is the current latest release. Everything else is reported with a warning naming what is missing *and* what superseded it.

## Verification — run against the real releases

```
v2.18.1 -> superseded by v2.18.2: REPORT ONLY (no demote)
v2.18.2 -> is latest: WOULD DEMOTE if incomplete
v9.9.9  -> no release, nothing to demote
```

Also confirmed `gh release view --json tagName` with no tag argument returns `v2.18.2`, i.e. the latest — the assumption the guard rests on. All four `run` blocks pass `bash -n`.

## Consequence

**v2.18.1 stays exactly as it is** — incomplete, superseded, untouched. That is now the documented intent rather than an oversight.