### PR TITLE
fix(ci): the GHCR publish workflow could never build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # Required by the GitHub Actions cache below. The runner's default builder
+      # uses the plain `docker` driver, which cannot export a cache at all —
+      # `cache-to: type=gha` made the build fail before it started, every time,
+      # with "Cache export is not supported for the docker driver". This action
+      # provisions the `docker-container` driver, which supports both the cache
+      # export and the `load: true` the verification steps below depend on.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Build the image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -32,10 +32,12 @@ RUN apt-get update \
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# PySide6 is a base dependency because the voice-activity overlay ships in the
-# default install. The overlay is a desktop feature and cannot run here, so it
-# is excluded to keep the image roughly a gigabyte smaller. Transcription never
-# imports it.
+# PySide6 is no longer a base dependency — v2.18.0 moved Qt into the optional
+# `desktop` extra, which is why a plain install is ~650 MB lighter than it was.
+# Installing plain `yazses` therefore already excludes it and the uninstall below
+# is a no-op kept only as a belt-and-braces guard: if Qt ever returns to the base
+# dependencies it would add roughly a gigabyte to an image that can never display
+# a window. Transcription does not import it.
 RUN pip install --no-cache-dir --upgrade pip \
  && pip install --no-cache-dir "yazses${YAZSES_VERSION:+==$YAZSES_VERSION}" \
  && pip uninstall -y PySide6 PySide6-Addons PySide6-Essentials shiboken6 || true


### PR DESCRIPTION
No container image has ever been published, and the reason is not policy — the workflow **cannot build**.

```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

`cache-to: type=gha` requires a builder that can export a cache; the runner's default `docker` driver cannot. Because the workflow is `workflow_dispatch`-only, nothing surfaced this until someone actually asked for an image. Found by requesting one (run [31730663883](https://github.com/MSKazemi/yazses/actions/runs/31730663883)) — it failed in 10 seconds, before the first layer.

This is the third instance of the same shape today: a correct, complete pipeline that had never once executed (SignPath signing, the packaging-manifest guards, and now this).

## Fix

Adds `docker/setup-buildx-action`, which provisions the `docker-container` driver — it supports the GHA cache export *and* the `load: true` that the "verify it actually transcribes" and "prove it works fully offline" steps depend on. Pinned by SHA to v4.2.0, the current stable.

The workflow stays `workflow_dispatch`-only. Its own header argues that publishing an image is a maintainer decision rather than a side effect of tagging, and this PR does not change that.

## Also

The Dockerfile claimed "PySide6 is a base dependency because the voice-activity overlay ships in the default install". Not true since v2.18.0 moved Qt into the optional `desktop` extra — that is exactly why a plain install is ~650 MB lighter. The `pip uninstall` is now a no-op, kept as a guard in case Qt ever returns to the base dependencies, and the comment says so.

Once merged, run the workflow with `push: true` to publish `ghcr.io/mskazemi/yazses`.