### PR TITLE
fix(ci): the image verification could never write the model cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,7 +86,15 @@ jobs:
           # the input — so `jfk.wav` produced `jfk.txt`, silently overwriting the
           # known-correct text the reader was being told to compare against. The
           # comparison then always looked perfect regardless of what the model said.
-          mkdir -p /tmp/out
+          # Both mounts must be writable by the image's unprivileged user (uid
+          # 1000). Docker creates a missing bind-mount source as root, so the
+          # first run failed with "Permission denied: '/models/hub'" the moment
+          # the model download tried to write — the container cannot chown a
+          # host directory. Creating them here, world-writable, is what the
+          # documented `docker run` relies on a normal user's own directories
+          # providing.
+          mkdir -p /tmp/out /tmp/models
+          chmod 0777 /tmp/out /tmp/models
           docker run --rm -v /tmp/models:/models \
             -v "$PWD/data/librispeech-sample:/data:ro" -v /tmp/out:/out \
             yazses:ci jfk.wav -o /out/jfk-heard.txt


### PR DESCRIPTION
Second failure in the container publish path, uncovered only because #275 let the build reach the verification step for the first time.

```
PermissionError: [Errno 13] Permission denied: '/models/hub'
```

The step bind-mounts `/tmp/models` into a container running as uid 1000, but Docker creates a **missing** bind-mount source owned by root. A container cannot chown a host directory, so the model download could never write and this step could never have passed.

Creates both mount points world-writable first — which is what the documented `docker run` gets for free from a normal user's own directories.

The verification itself is worth keeping intact: it transcribes a real clip and diffs against known-correct text, then repeats it with `--network none` to prove the offline claim before anything is published.