### PR TITLE
fix(flatpak): install the KDE SDK before resolving wheels against it

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -51,6 +51,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # The flathub-infra image ships flatpak-builder but no runtimes, and
+      # --runtime makes the generator exec python3 *inside* org.kde.Sdk to read
+      # its platform tags. Without the SDK present that fails with "Failed to
+      # obtain platform tags from runtime", which is the generator saying it
+      # cannot see the interpreter it is resolving wheels for.
+      - name: Install the KDE SDK the wheels are resolved against
+        run: |
+          set -eux
+          flatpak remote-add --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install -y --noninteractive flathub \
+            "org.kde.Sdk//${RUNTIME_VERSION}" "org.kde.Platform//${RUNTIME_VERSION}"
+          flatpak list --runtime --columns=application,branch
+
       - name: Fetch flatpak-pip-generator
         run: |
           set -euo pipefail


### PR DESCRIPTION
Third and hopefully last step of getting the Flathub dependency file generated.

```
Failed to obtain platform tags from runtime. Cannot select platform wheels.
```

The `flathub-infra` CI image ships `flatpak-builder` but **no runtimes**. `--runtime` makes the generator exec `python3` *inside* `org.kde.Sdk` to read its platform tags — so it was being asked to resolve wheels for an interpreter that was not installed.

Installs `org.kde.Sdk` and `org.kde.Platform` at the manifest's `runtime-version` first, and prints the installed runtime list so a future version mismatch shows up directly in the log instead of as a confusing downstream error.

Progress so far on this chain: generator refused binary-only wheels (#278) → now the SDK itself was absent. Each failure has been a real missing prerequisite, which is why the Flathub submission never happened.