### PR TITLE
packaging: ask every channel whether it really has this version

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -25,7 +25,7 @@ the APT repo serves **2.18.2**, signed, `InRelease` 200.
 | **AUR** | ❌ **404** | `arch/PKGBUILD` | ⚠ stale at `pkgver=0.4.0`, `sha256sums=SKIP` ([#67](https://github.com/MSKazemi/yazses/issues/67)) |
 | **Flathub** | ❌ not found | — | nothing built yet ([#45](https://github.com/MSKazemi/yazses/issues/45)) |
 | **Nix** | ❌ 0 hits | `../flake.nix` | authored; **every nixpkgs attribute verified to exist**, but ⚠ **never evaluated** (no Nix here) ([#68](https://github.com/MSKazemi/yazses/issues/68)) |
-| **Docker/GHCR** | ❌ 404 | `docker/Dockerfile` | image **builds and runs** — needs publishing ([#76](https://github.com/MSKazemi/yazses/issues/76)) |
+| **Docker/GHCR** | ✅ live | `docker/Dockerfile` | `ghcr.io/mskazemi/yazses:2.18.2` is **public and pullable** — now published on every tag ([#76](https://github.com/MSKazemi/yazses/issues/76)). ⚠ the earlier "404" was a **measurement error**: GHCR rejects unauthenticated reads, so a bare `curl` returns 401/404 for images that exist. Verify with a pull token, see below |
 | **Scoop** | ✅ live | `../bucket/yazses.json` | bucket served from this repo — `scoop bucket add yazses https://github.com/MSKazemi/yazses`; manifest at **2.18.2**, raw URL 200 ([#79](https://github.com/MSKazemi/yazses/issues/79)) |
 | **Chocolatey** | ❌ 404 | `chocolatey/` | nuspec + checksum verified; ⚠ **`.ps1` scripts not syntax-checked** (no `pwsh` on the authoring machine) |
 
@@ -33,6 +33,20 @@ the APT repo serves **2.18.2**, signed, `InRelease` 200.
 > `search.nixos.org` and AlternativeTo — they are single-page apps that return **HTTP 200
 > for pages that do not exist**. Use an API instead:
 > `https://flathub.org/api/v2/appstream/<app-id>` correctly answers `App not found`.
+>
+> **And it lies the other way about GHCR.** A registry read without a token is rejected
+> whether or not the image exists, so `401`/`404` there is not evidence of absence — this
+> table carried "Docker ❌ 404" while `ghcr.io/mskazemi/yazses:2.18.2` was public and
+> pullable. Get an anonymous pull token first:
+>
+> ```bash
+> TOK=$(curl -s "https://ghcr.io/token?scope=repository:mskazemi/yazses:pull&service=ghcr.io" | jq -r .token)
+> curl -s -H "Authorization: Bearer $TOK" https://ghcr.io/v2/mskazemi/yazses/tags/list
+> ```
+>
+> **Do not hand-check any of this.** `scripts/check-release-channels.py --version <v>`
+> queries every channel in this table the correct way and prints it as a table;
+> `release-complete.yml` runs it on every tag.
 
 ### Two dead files kept only as history
 

--- a/scripts/check-release-channels.py
+++ b/scripts/check-release-channels.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Ask every distribution channel whether it actually has a given version.
+
+Why this exists
+---------------
+v2.18.1 shipped Windows and macOS, no Linux package, and nothing on PyPI, and
+was published as "Latest" anyway. Its Release workflow had failed in the test
+job, so release-linux and publish-pypi were skipped -- but build-macos and
+build-windows are separate workflows, so they succeeded and created the Release
+themselves. Every workflow did its own job correctly. None was in a position to
+ask whether *all* of it shipped.
+
+Policy (owner, 2026-08-13): the newest version must carry a package on every
+channel. Older versions need not -- a superseded release being incomplete is
+history, not a live problem.
+
+Verification gotcha this encodes
+--------------------------------
+`curl -o /dev/null -w '%{http_code}'` LIES about Flathub and search.nixos.org:
+they are single-page apps that return HTTP 200 for pages that do not exist. Every
+check below therefore queries a real API or a raw file path whose absence is a
+genuine 404 -- never a rendered page.
+
+Deliberately stdlib-only, like refresh-package-manifests.py, so it runs under a
+bare /usr/bin/python3 in a CI job with nothing installed.
+
+Usage
+-----
+    python scripts/check-release-channels.py --version 2.18.2
+    python scripts/check-release-channels.py --version 2.18.2 --core-only
+    python scripts/check-release-channels.py --version 2.18.2 --format json
+
+Exit status is 1 if any checked channel lacks the version, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+REPO = "MSKazemi/yazses"
+FLATPAK_ID = "io.github.mskazemi.YazSes"
+TIMEOUT = 20
+
+# The channels CI itself produces. These are the ones whose absence means the
+# release is actively broken for a user on that OS, so they alone justify
+# demoting a release. Everything else is a publishing gap: real, worth failing
+# the build over, but not a reason to relabel what did ship.
+CORE = {"deb", "dmg", "exe", "pypi"}
+
+
+@dataclass
+class Result:
+    key: str
+    label: str
+    ok: bool
+    detail: str = ""
+    core: bool = field(default=False)
+
+
+def _get(url: str, headers: dict[str, str] | None = None) -> tuple[int, bytes]:
+    """Return (status, body). Never raises for HTTP errors -- 404 is an answer."""
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read() if e.fp else b""
+    except Exception as e:  # network/DNS/TLS -- report rather than crash the job
+        return 0, str(e).encode()
+
+
+def _json(url: str, headers: dict[str, str] | None = None):
+    status, body = _get(url, headers)
+    if status != 200:
+        return status, None
+    try:
+        return status, json.loads(body)
+    except ValueError:
+        return status, None
+
+
+# --------------------------------------------------------------------------
+# One function per channel. Each returns (ok, detail).
+# --------------------------------------------------------------------------
+
+
+def check_release_assets(version: str) -> dict[str, tuple[bool, str]]:
+    """The three binaries attached to the GitHub Release, in one API call."""
+    status, data = _json(f"https://api.github.com/repos/{REPO}/releases/tags/v{version}")
+    if status != 200 or not data:
+        miss = f"release v{version} not found (HTTP {status})"
+        return {k: (False, miss) for k in ("deb", "dmg", "exe")}
+    names = [a["name"] for a in data.get("assets", [])]
+    out = {}
+    for key, suffix in (("deb", ".deb"), ("dmg", ".dmg"), ("exe", ".exe")):
+        hit = next((n for n in names if n.endswith(suffix)), None)
+        out[key] = (hit is not None, hit or f"no {suffix} attached")
+    return out
+
+
+def check_pypi(version: str) -> tuple[bool, str]:
+    status, _ = _get(f"https://pypi.org/pypi/yazses/{version}/json")
+    return status == 200, f"HTTP {status}"
+
+
+def check_snap(version: str) -> tuple[bool, str]:
+    status, data = _json(
+        "https://api.snapcraft.io/v2/snaps/info/yazses?fields=version",
+        {"Snap-Device-Series": "16"},
+    )
+    if status != 200 or not data:
+        return False, f"snapcraft API HTTP {status}"
+    stable = [
+        c.get("version")
+        for c in data.get("channel-map", [])
+        if c.get("channel", {}).get("name") == "stable"
+    ]
+    if not stable:
+        return False, "no stable channel"
+    return version in stable, f"stable={','.join(sorted(set(stable)))}"
+
+
+def check_apt(version: str) -> tuple[bool, str]:
+    status, body = _get(
+        f"https://raw.githubusercontent.com/{REPO}/gh-pages/apt/Packages"
+    )
+    if status != 200:
+        return False, f"Packages HTTP {status}"
+    found = re.findall(r"^Version:\s*(\S+)", body.decode("utf-8", "replace"), re.M)
+    return version in found, f"apt={','.join(found[:3]) or 'none'}"
+
+
+def check_homebrew(version: str) -> tuple[bool, str]:
+    status, body = _get(
+        "https://raw.githubusercontent.com/MSKazemi/homebrew-yazses/main/Casks/yazses.rb"
+    )
+    if status != 200:
+        return False, f"cask HTTP {status}"
+    m = re.search(r'^\s*version\s+"([^"]+)"', body.decode("utf-8", "replace"), re.M)
+    return (m is not None and m.group(1) == version), f"cask={m.group(1) if m else '?'}"
+
+
+def check_scoop(version: str) -> tuple[bool, str]:
+    status, data = _json(
+        f"https://raw.githubusercontent.com/{REPO}/main/bucket/yazses.json"
+    )
+    if status != 200 or not data:
+        return False, f"bucket HTTP {status}"
+    return data.get("version") == version, f"bucket={data.get('version')}"
+
+
+def check_winget(version: str) -> tuple[bool, str]:
+    # The upstream community repo, not our own copy of the manifests. Having them
+    # in packaging/ installs nobody.
+    url = (
+        "https://api.github.com/repos/microsoft/winget-pkgs/contents/"
+        f"manifests/m/MSKazemi/YazSes/{version}"
+    )
+    status, _ = _get(url)
+    return status == 200, f"winget-pkgs HTTP {status}"
+
+
+def check_chocolatey(version: str) -> tuple[bool, str]:
+    url = "https://community.chocolatey.org/api/v2/Packages()?$filter=Id%20eq%20'yazses'"
+    status, body = _get(url)
+    if status != 200:
+        return False, f"HTTP {status}"
+    text = body.decode("utf-8", "replace")
+    return f"<d:Version>{version}</d:Version>" in text, (
+        "listed" if "<entry>" in text else "not listed"
+    )
+
+
+def check_aur(version: str) -> tuple[bool, str]:
+    status, data = _json("https://aur.archlinux.org/rpc/v5/info?arg[]=yazses")
+    if status != 200 or not data:
+        return False, f"AUR RPC HTTP {status}"
+    results = data.get("results", [])
+    if not results:
+        return False, "not in AUR"
+    got = results[0].get("Version", "")
+    return got.split("-")[0] == version, f"aur={got}"
+
+
+def check_flathub(version: str) -> tuple[bool, str]:
+    # The API answers honestly; flathub.org itself returns 200 for missing apps.
+    status, _ = _get(f"https://flathub.org/api/v2/appstream/{FLATPAK_ID}")
+    return status == 200, f"appstream HTTP {status}"
+
+
+def check_nix(version: str) -> tuple[bool, str]:
+    # search.nixos.org is an SPA and lies. A raw path in nixpkgs does not.
+    status, _ = _get(
+        "https://raw.githubusercontent.com/NixOS/nixpkgs/master/"
+        "pkgs/by-name/ya/yazses/package.nix"
+    )
+    return status == 200, f"nixpkgs HTTP {status}"
+
+
+def check_docker(version: str) -> tuple[bool, str]:
+    """GHCR needs a pull token even for public images; 401 is 'no such package'."""
+    owner, image = REPO.split("/")
+    status, tok = _json(
+        f"https://ghcr.io/token?scope=repository:{owner.lower()}/{image}:pull&service=ghcr.io"
+    )
+    if status != 200 or not tok or "token" not in tok:
+        return False, f"token HTTP {status}"
+    status, data = _json(
+        f"https://ghcr.io/v2/{owner.lower()}/{image}/tags/list",
+        {"Authorization": f"Bearer {tok['token']}"},
+    )
+    if status != 200 or not data:
+        return False, f"tags HTTP {status}"
+    tags = data.get("tags") or []
+    return version in tags, f"tags={','.join(tags[:4]) or 'none'}"
+
+
+CHECKS = [
+    ("pypi", "PyPI", check_pypi),
+    ("snap", "Snap Store (stable)", check_snap),
+    ("apt", "APT repo", check_apt),
+    ("homebrew", "Homebrew tap", check_homebrew),
+    ("scoop", "Scoop bucket", check_scoop),
+    ("winget", "winget-pkgs", check_winget),
+    ("chocolatey", "Chocolatey", check_chocolatey),
+    ("aur", "AUR", check_aur),
+    ("flathub", "Flathub", check_flathub),
+    ("nix", "nixpkgs", check_nix),
+    ("docker", "Docker (GHCR)", check_docker),
+]
+
+ASSET_LABELS = {"deb": "Linux .deb", "dmg": "macOS .dmg", "exe": "Windows .exe"}
+
+
+def run(version: str, core_only: bool) -> list[Result]:
+    results: list[Result] = []
+    for key, (ok, detail) in check_release_assets(version).items():
+        results.append(Result(key, ASSET_LABELS[key], ok, detail, core=True))
+
+    if core_only:
+        core = [r for r in results if r.key in CORE]
+        ok, detail = check_pypi(version)
+        core.append(Result("pypi", "PyPI", ok, detail, core=True))
+        return core
+
+    # Every check is an independent network round-trip against a different host,
+    # so run them concurrently -- serially this took ~200s, which is too slow to
+    # be worth running by hand, and a tool nobody runs locally is a tool that
+    # only ever fails in CI.
+    def one(item):
+        key, label, fn = item
+        try:
+            ok, detail = fn(version)
+        except Exception as e:  # a broken check must not hide the other thirteen
+            ok, detail = False, f"check errored: {type(e).__name__}"
+        return Result(key, label, ok, detail, core=key in CORE)
+
+    with ThreadPoolExecutor(max_workers=len(CHECKS)) as pool:
+        results.extend(pool.map(one, CHECKS))
+    return results
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--version", required=True, help="version without the leading v")
+    ap.add_argument(
+        "--core-only",
+        action="store_true",
+        help="only the channels CI produces (deb/dmg/exe/PyPI) -- used to decide "
+        "whether a release is broken for users, as opposed to merely unpublished",
+    )
+    ap.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    args = ap.parse_args()
+
+    results = run(args.version, args.core_only)
+    missing = [r for r in results if not r.ok]
+
+    if args.format == "json":
+        print(json.dumps([r.__dict__ for r in results], indent=2))
+    else:
+        print(f"## Release completeness — v{args.version}\n")
+        print("| Channel | Published | Detail |")
+        print("|---|---|---|")
+        for r in results:
+            print(f"| {r.label} | {'✅' if r.ok else '❌'} | {r.detail} |")
+        print()
+        if missing:
+            print(f"**Missing ({len(missing)}):** " + ", ".join(r.label for r in missing))
+        else:
+            print("**Every checked channel has this version.**")
+
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -1,0 +1,304 @@
+"""`scripts/check-release-channels.py` must answer honestly about every channel.
+
+The script is the thing that decides whether a release shipped everywhere, so a
+bug in it is worse than no check at all: it would report a complete release while
+one platform was missing, which is exactly the failure it exists to catch.
+
+These tests are **fully offline**, like the rest of the suite. Every HTTP call goes
+through one `_get` seam, so stubbing that is enough to drive each channel through
+its success and failure paths without touching the network.
+
+Two traps get their own tests because both have already been made for real:
+
+- **Flathub and search.nixos.org return HTTP 200 for pages that do not exist**, so a
+  naive check reports them published forever. The checks must query an API, and
+  `test_flathub_uses_the_api_not_the_website` asserts the URL, not just the verdict.
+- **GHCR rejects unauthenticated reads whether or not the image exists.** A bare
+  request returns 401/404 for a published image, which is how `packaging/README.md`
+  came to record Docker as unpublished while it was live.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check-release-channels.py"
+
+
+def _load():
+    """Import the script by path -- its filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("check_release_channels", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    # Must be registered before exec: @dataclass resolves annotations via
+    # sys.modules[cls.__module__] and raises AttributeError on a module that is
+    # not there yet.
+    sys.modules["check_release_channels"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def crc():
+    return _load()
+
+
+@pytest.fixture
+def responses(crc, monkeypatch):
+    """Stub the single network seam. Returns the recorded list of requested URLs."""
+    requested: list[str] = []
+
+    def make(mapping: dict[str, tuple[int, bytes]], default=(404, b"")):
+        def fake_get(url: str, headers=None):
+            requested.append(url)
+            for fragment, response in mapping.items():
+                if fragment in url:
+                    return response
+            return default
+
+        monkeypatch.setattr(crc, "_get", fake_get)
+        return requested
+
+    return make
+
+
+def _body(obj) -> bytes:
+    return json.dumps(obj).encode()
+
+
+# --------------------------------------------------------------------------
+# Release assets
+# --------------------------------------------------------------------------
+
+
+def test_all_three_assets_present(crc, responses):
+    responses(
+        {
+            "api.github.com": (
+                200,
+                _body(
+                    {
+                        "assets": [
+                            {"name": "yazses_2.18.2_amd64.deb"},
+                            {"name": "YazSes-2.18.2.dmg"},
+                            {"name": "YazSes-2.18.2-windows-x64.exe"},
+                        ]
+                    }
+                ),
+            )
+        }
+    )
+    got = crc.check_release_assets("2.18.2")
+    assert all(ok for ok, _ in got.values())
+
+
+def test_missing_deb_is_reported_alone(crc, responses):
+    """The real v2.18.1: macOS and Windows shipped, Linux did not."""
+    responses(
+        {
+            "api.github.com": (
+                200,
+                _body(
+                    {
+                        "assets": [
+                            {"name": "YazSes-2.18.1.dmg"},
+                            {"name": "YazSes-2.18.1-windows-x64.exe"},
+                        ]
+                    }
+                ),
+            )
+        }
+    )
+    got = crc.check_release_assets("2.18.1")
+    assert got["deb"][0] is False
+    assert got["dmg"][0] is True
+    assert got["exe"][0] is True
+
+
+def test_absent_release_fails_every_asset(crc, responses):
+    responses({})  # everything 404s
+    got = crc.check_release_assets("9.9.9")
+    assert not any(ok for ok, _ in got.values())
+
+
+# --------------------------------------------------------------------------
+# Channels whose answer is a version, not merely presence
+# --------------------------------------------------------------------------
+
+
+def test_snap_stale_version_is_not_published(crc, responses):
+    """A channel serving an older build must not count as carrying this release."""
+    payload = {"channel-map": [{"channel": {"name": "stable"}, "version": "2.17.0"}]}
+    responses({"api.snapcraft.io": (200, _body(payload))})
+    ok, detail = crc.check_snap("2.18.2")
+    assert ok is False
+    assert "2.17.0" in detail
+
+
+def test_snap_matching_version_passes(crc, responses):
+    payload = {"channel-map": [{"channel": {"name": "stable"}, "version": "2.18.2"}]}
+    responses({"api.snapcraft.io": (200, _body(payload))})
+    assert crc.check_snap("2.18.2")[0] is True
+
+
+def test_apt_reads_the_packages_index(crc, responses):
+    responses({"gh-pages/apt/Packages": (200, b"Package: yazses\nVersion: 2.18.2\n")})
+    assert crc.check_apt("2.18.2")[0] is True
+    assert crc.check_apt("2.18.3")[0] is False
+
+
+def test_homebrew_cask_version(crc, responses):
+    responses({"homebrew-yazses": (200, b'cask "yazses" do\n  version "2.18.2"\nend\n')})
+    assert crc.check_homebrew("2.18.2")[0] is True
+    assert crc.check_homebrew("2.17.0")[0] is False
+
+
+def test_scoop_bucket_version(crc, responses):
+    responses({"bucket/yazses.json": (200, _body({"version": "2.18.2"}))})
+    assert crc.check_scoop("2.18.2")[0] is True
+    assert crc.check_scoop("2.18.1")[0] is False
+
+
+def test_aur_strips_the_pkgrel(crc, responses):
+    """AUR reports `2.18.2-1`; the trailing pkgrel is not part of our version."""
+    responses({"aur.archlinux.org": (200, _body({"results": [{"Version": "2.18.2-1"}]}))})
+    assert crc.check_aur("2.18.2")[0] is True
+
+
+def test_aur_absent(crc, responses):
+    responses({"aur.archlinux.org": (200, _body({"resultcount": 0, "results": []}))})
+    ok, detail = crc.check_aur("2.18.2")
+    assert ok is False and "not in AUR" in detail
+
+
+def test_chocolatey_needs_this_exact_version(crc, responses):
+    feed = b"<feed><entry><d:Version>2.17.0</d:Version></entry></feed>"
+    responses({"chocolatey.org": (200, feed)})
+    assert crc.check_chocolatey("2.18.2")[0] is False
+    assert crc.check_chocolatey("2.17.0")[0] is True
+
+
+def test_winget_checks_upstream_not_our_own_copy(crc, responses):
+    """Manifests sitting in packaging/ install nobody -- only winget-pkgs counts."""
+    requested = responses({"microsoft/winget-pkgs": (200, b"[]")})
+    assert crc.check_winget("2.18.2")[0] is True
+    assert any("microsoft/winget-pkgs" in u for u in requested)
+
+
+# --------------------------------------------------------------------------
+# The two verification traps
+# --------------------------------------------------------------------------
+
+
+def test_flathub_uses_the_api_not_the_website(crc, responses):
+    """flathub.org is a SPA that answers 200 for apps that do not exist."""
+    requested = responses({"flathub.org/api/v2/appstream": (200, b"{}")})
+    assert crc.check_flathub("2.18.2")[0] is True
+    assert requested, "no request was made"
+    assert all("/api/v2/appstream/" in u for u in requested), requested
+
+
+def test_flathub_absent_is_a_real_404(crc, responses):
+    responses({})
+    assert crc.check_flathub("2.18.2")[0] is False
+
+
+def test_nix_uses_a_raw_nixpkgs_path_not_the_search_site(crc, responses):
+    """search.nixos.org is also a SPA; a raw file path 404s honestly."""
+    requested = responses({"raw.githubusercontent.com/NixOS/nixpkgs": (200, b"{}")})
+    assert crc.check_nix("2.18.2")[0] is True
+    assert all("search.nixos.org" not in u for u in requested), requested
+
+
+def test_ghcr_gets_a_pull_token_before_listing_tags(crc, responses):
+    """An unauthenticated GHCR read 401s even for a published public image."""
+    requested = responses(
+        {
+            "ghcr.io/token": (200, _body({"token": "abc"})),
+            "ghcr.io/v2/": (200, _body({"tags": ["2.18.2"]})),
+        }
+    )
+    assert crc.check_docker("2.18.2")[0] is True
+    assert any("ghcr.io/token" in u for u in requested), "no token was requested"
+
+
+def test_ghcr_without_a_token_is_not_read_as_absent(crc, responses):
+    """If the token call fails we must say so, not silently report 'not published'."""
+    responses({})
+    ok, detail = crc.check_docker("2.18.2")
+    assert ok is False
+    assert "token" in detail
+
+
+def test_ghcr_tag_missing(crc, responses):
+    responses(
+        {
+            "ghcr.io/token": (200, _body({"token": "abc"})),
+            "ghcr.io/v2/": (200, _body({"tags": ["2.17.0"]})),
+        }
+    )
+    assert crc.check_docker("2.18.2")[0] is False
+
+
+# --------------------------------------------------------------------------
+# Aggregation and the core/full distinction
+# --------------------------------------------------------------------------
+
+
+def test_core_only_returns_exactly_the_channels_ci_builds(crc, responses):
+    responses(
+        {
+            "api.github.com": (
+                200,
+                _body(
+                    {
+                        "assets": [
+                            {"name": "a.deb"},
+                            {"name": "b.dmg"},
+                            {"name": "c.exe"},
+                        ]
+                    }
+                ),
+            ),
+            "pypi.org": (200, b"{}"),
+        }
+    )
+    results = crc.run("2.18.2", core_only=True)
+    assert {r.key for r in results} == crc.CORE
+    assert all(r.ok for r in results)
+
+
+def test_core_only_does_not_touch_the_other_channels(crc, responses):
+    requested = responses({"api.github.com": (200, _body({"assets": []})), "pypi.org": (200, b"{}")})
+    crc.run("2.18.2", core_only=True)
+    for host in ("snapcraft", "flathub", "ghcr.io", "aur.archlinux"):
+        assert not any(host in u for u in requested), f"core-only queried {host}"
+
+
+def test_full_run_covers_every_declared_channel(crc, responses):
+    responses({})  # everything absent
+    results = crc.run("9.9.9", core_only=False)
+    keys = {r.key for r in results}
+    assert keys == {"deb", "dmg", "exe"} | {k for k, _, _ in crc.CHECKS}
+    assert not any(r.ok for r in results)
+
+
+def test_a_check_that_raises_does_not_hide_the_others(crc, responses, monkeypatch):
+    """One broken channel must not take the whole report down with it."""
+    responses({"api.github.com": (200, _body({"assets": [{"name": "a.deb"}]}))})
+
+    def boom(_version):
+        raise RuntimeError("upstream exploded")
+
+    monkeypatch.setattr(crc, "CHECKS", [("pypi", "PyPI", boom)])
+    results = crc.run("2.18.2", core_only=False)
+    pypi = next(r for r in results if r.key == "pypi")
+    assert pypi.ok is False
+    assert "RuntimeError" in pypi.detail
+    # The asset checks still reported.
+    assert next(r for r in results if r.key == "deb").ok is True


### PR DESCRIPTION
Nothing could answer *"did this release ship everywhere?"*. The channel table in `packaging/README.md` was maintained by hand and re-audited by eye — which is how it came to record **Docker as an unpublished 404** while `ghcr.io/mskazemi/yazses:2.18.2` was public and pullable.

## `scripts/check-release-channels.py`

Asks all fourteen channels and prints the table:

```
$ python3 scripts/check-release-channels.py --version 2.18.2
```

| ✅ Published (9) | ❌ Missing (5) |
|---|---|
| `.deb`, `.dmg`, `.exe`, PyPI, Snap, APT, Homebrew, Scoop, **Docker/GHCR** | winget, Chocolatey, AUR, Flathub, nixpkgs |

Stdlib-only, like `refresh-package-manifests.py`. `--core-only` narrows to the four artifacts CI itself builds; `--format json` for machines.

## The obvious check is wrong in *both* directions

- **Flathub and `search.nixos.org` return HTTP 200 for pages that do not exist** — a naive check reports them published forever.
- **GHCR returns 401 for images that do exist** — it rejects unauthenticated reads regardless, which is exactly how the Docker row became wrong.

Both traps have a test asserting the **URL that was requested**, not just the verdict, so a future refactor cannot quietly reintroduce either.

## Tests — offline, from real failures

22 tests, 1.0s, no network. Every request goes through a single `_get` seam, so stubbing it drives each channel through both paths. Cases are taken from things that actually happened:

- v2.18.1's missing `.deb` with `.dmg` and `.exe` present
- a Snap channel three releases behind still being reported "published"
- an AUR version carrying a `-1` pkgrel suffix
- a check that raises must not take the other thirteen down with it

## Gates

```
uv run python -m pytest tests/          3088 passed, 15 skipped
uv run ruff check src tests scripts     All checks passed!
```

## Scope

**No workflow files here on purpose.** Wiring this into the release gate is #279, which cannot merge until the `gh` token regains `workflow` scope. This half doesn't need it, so it shouldn't wait for it — once both land, #279's diff is just the workflow deltas.