### PR TITLE
docs(l10n): the Hindi and Russian READMEs still told Intel Mac users to take the .dmg

### DIFF
--- a/README.hi.md
+++ b/README.hi.md
@@ -404,12 +404,19 @@ yazses doctor                           # says if anything is still missing
 ### macOS
 
 ```sh
-# pipx (Python ≥ 3.11)
+# Homebrew — Apple Silicon only
+brew tap MSKazemi/yazses
+brew install --cask yazses
+
+# pipx (Python ≥ 3.11) — works on Apple Silicon AND Intel
 pipx install yazses
 
-# App bundle (.dmg) — unsigned developer preview
+# App bundle (.dmg) — unsigned developer preview, Apple Silicon only
 # https://github.com/MSKazemi/yazses/releases/latest
 ```
+
+> **On an Intel Mac, use pipx.** The `.dmg` has no `x86_64` slice and cannot launch there.
+> See [docs/macos-install.md](docs/macos-install.md).
 
 ### Windows
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -423,12 +423,19 @@ yazses doctor                           # says if anything is still missing
 ### macOS
 
 ```sh
-# pipx (Python ≥ 3.11)
+# Homebrew — Apple Silicon only
+brew tap MSKazemi/yazses
+brew install --cask yazses
+
+# pipx (Python ≥ 3.11) — works on Apple Silicon AND Intel
 pipx install yazses
 
-# App bundle (.dmg) — unsigned developer preview
+# App bundle (.dmg) — unsigned developer preview, Apple Silicon only
 # https://github.com/MSKazemi/yazses/releases/latest
 ```
+
+> **On an Intel Mac, use pipx.** The `.dmg` has no `x86_64` slice and cannot launch there.
+> See [docs/macos-install.md](docs/macos-install.md).
 
 ### Windows
 


### PR DESCRIPTION
`README.md` was corrected when the arm64-only `.dmg` was found (#263). **Its translations were not.**

`README.hi.md` and `README.ru.md` kept offering the `.dmg` with no architecture caveat and no mention of the Homebrew tap — so a Hindi or Russian reader was told to download a bundle that **cannot launch on their machine**, while the English reader was warned.

## Why now

YazSes was just submitted to [awesome-mac](https://github.com/jaywcjlove/awesome-mac/pull/2562) (110k ★), whose entries are synced across its English, Chinese, Japanese and Korean READMEs. **Non-English readers are precisely the traffic being invited in.** Fixing the English page only would have been fixing the page least at risk.

## How, without inventing prose I cannot check

Both macOS blocks are **pure English in these files** — the code fences were never translated. So the fact rides in the comments, which already read as English:

```sh
# Homebrew — Apple Silicon only
# pipx (Python ≥ 3.11) — works on Apple Silicon AND Intel
# App bundle (.dmg) — unsigned developer preview, Apple Silicon only
```

plus one English line pointing at `docs/macos-install.md`, matching the untranslated technical prose already present in those same sections (e.g. *"always pulls the latest published release from PyPI"* sits untranslated in both today).

I did not fabricate Hindi or Russian technical prose. **A native speaker should translate the note** — but the wrong instruction should not wait for that. Flagging for whoever picks up #166 (translation drift checker), which would have caught this automatically.

`README.zh-CN.md` is a partial translation with no per-OS install blocks, so it carried no claim to correct.

## Verification

- Both files now state Apple Silicon twice (code comment + note); zh-CN correctly unchanged
- `ruff` clean · **3286 passed, 17 skipped**
- Docs only — no `src/` changes