### PR TITLE
fix(scripts): unreachable is not the same as unpublished

### DIFF
--- a/scripts/check-release-channels.py
+++ b/scripts/check-release-channels.py
@@ -30,7 +30,7 @@ Usage
     python scripts/check-release-channels.py --version 2.18.2 --core-only
     python scripts/check-release-channels.py --version 2.18.2 --format json
 
-Exit status is 1 if any checked channel lacks the version, 0 otherwise.
+Exit status is 1 if any channel lacks the version OR could not be reached.
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ import argparse
 import json
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
@@ -47,6 +48,20 @@ from dataclasses import dataclass, field
 REPO = "MSKazemi/yazses"
 FLATPAK_ID = "io.github.mskazemi.YazSes"
 TIMEOUT = 20
+RETRIES = 3
+RETRY_BACKOFF_S = 2
+
+# A check answers one of three things, and conflating the last two is how a
+# dropped connection gets reported as an unpublished package:
+#   True  -- this channel has this version
+#   False -- this channel answered, and does not have it
+#   None  -- the channel could not be reached, so we do not know
+UNKNOWN = None
+
+
+def _verdict(status: int, published: bool) -> bool | None:
+    """Map an HTTP status onto the tri-state. Status 0 means 'never answered'."""
+    return UNKNOWN if status == 0 else published
 
 # The channels CI itself produces. These are the ones whose absence means the
 # release is actively broken for a user on that OS, so they alone justify
@@ -59,21 +74,34 @@ CORE = {"deb", "dmg", "exe", "pypi"}
 class Result:
     key: str
     label: str
-    ok: bool
+    ok: bool | None  # True published / False absent / None unreachable
     detail: str = ""
     core: bool = field(default=False)
 
 
 def _get(url: str, headers: dict[str, str] | None = None) -> tuple[int, bytes]:
-    """Return (status, body). Never raises for HTTP errors -- 404 is an answer."""
+    """Return (status, body). Never raises for HTTP errors -- 404 is an answer.
+
+    Status 0 means the request never completed (DNS, TLS, timeout, reset). That is
+    NOT the same as a 404 and must never be read as "not published": on 2026-08-13
+    a single dropped connection to aur.archlinux.org made this report the AUR as
+    absent, and three retries a moment later all returned 200.
+
+    Transient failures are retried before giving up, because most of them are.
+    """
     req = urllib.request.Request(url, headers=headers or {})
-    try:
-        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
-            return r.status, r.read()
-    except urllib.error.HTTPError as e:
-        return e.code, e.read() if e.fp else b""
-    except Exception as e:  # network/DNS/TLS -- report rather than crash the job
-        return 0, str(e).encode()
+    last = b""
+    for attempt in range(RETRIES):
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+                return r.status, r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read() if e.fp else b""
+        except Exception as e:  # network/DNS/TLS
+            last = str(e).encode()
+            if attempt + 1 < RETRIES:
+                time.sleep(RETRY_BACKOFF_S * (attempt + 1))
+    return 0, last
 
 
 def _json(url: str, headers: dict[str, str] | None = None):
@@ -87,16 +115,19 @@ def _json(url: str, headers: dict[str, str] | None = None):
 
 
 # --------------------------------------------------------------------------
-# One function per channel. Each returns (ok, detail).
+# One function per channel. Each returns (published, detail), where `published`
+# is True / False / UNKNOWN -- see the note on UNKNOWN above.
 # --------------------------------------------------------------------------
 
 
-def check_release_assets(version: str) -> dict[str, tuple[bool, str]]:
+def check_release_assets(version: str) -> dict[str, tuple[bool | None, str]]:
     """The three binaries attached to the GitHub Release, in one API call."""
     status, data = _json(f"https://api.github.com/repos/{REPO}/releases/tags/v{version}")
     if status != 200 or not data:
         miss = f"release v{version} not found (HTTP {status})"
-        return {k: (False, miss) for k in ("deb", "dmg", "exe")}
+        if status == 0:
+            miss = "github.com unreachable"
+        return {k: (_verdict(status, False), miss) for k in ("deb", "dmg", "exe")}
     names = [a["name"] for a in data.get("assets", [])]
     out = {}
     for key, suffix in (("deb", ".deb"), ("dmg", ".dmg"), ("exe", ".exe")):
@@ -105,18 +136,18 @@ def check_release_assets(version: str) -> dict[str, tuple[bool, str]]:
     return out
 
 
-def check_pypi(version: str) -> tuple[bool, str]:
+def check_pypi(version: str) -> tuple[bool | None, str]:
     status, _ = _get(f"https://pypi.org/pypi/yazses/{version}/json")
-    return status == 200, f"HTTP {status}"
+    return _verdict(status, status == 200), f"HTTP {status}"
 
 
-def check_snap(version: str) -> tuple[bool, str]:
+def check_snap(version: str) -> tuple[bool | None, str]:
     status, data = _json(
         "https://api.snapcraft.io/v2/snaps/info/yazses?fields=version",
         {"Snap-Device-Series": "16"},
     )
     if status != 200 or not data:
-        return False, f"snapcraft API HTTP {status}"
+        return _verdict(status, False), f"snapcraft API HTTP {status}"
     stable = [
         c.get("version")
         for c in data.get("channel-map", [])
@@ -127,36 +158,36 @@ def check_snap(version: str) -> tuple[bool, str]:
     return version in stable, f"stable={','.join(sorted(set(stable)))}"
 
 
-def check_apt(version: str) -> tuple[bool, str]:
+def check_apt(version: str) -> tuple[bool | None, str]:
     status, body = _get(
         f"https://raw.githubusercontent.com/{REPO}/gh-pages/apt/Packages"
     )
     if status != 200:
-        return False, f"Packages HTTP {status}"
+        return _verdict(status, False), f"Packages HTTP {status}"
     found = re.findall(r"^Version:\s*(\S+)", body.decode("utf-8", "replace"), re.M)
     return version in found, f"apt={','.join(found[:3]) or 'none'}"
 
 
-def check_homebrew(version: str) -> tuple[bool, str]:
+def check_homebrew(version: str) -> tuple[bool | None, str]:
     status, body = _get(
         "https://raw.githubusercontent.com/MSKazemi/homebrew-yazses/main/Casks/yazses.rb"
     )
     if status != 200:
-        return False, f"cask HTTP {status}"
+        return _verdict(status, False), f"cask HTTP {status}"
     m = re.search(r'^\s*version\s+"([^"]+)"', body.decode("utf-8", "replace"), re.M)
     return (m is not None and m.group(1) == version), f"cask={m.group(1) if m else '?'}"
 
 
-def check_scoop(version: str) -> tuple[bool, str]:
+def check_scoop(version: str) -> tuple[bool | None, str]:
     status, data = _json(
         f"https://raw.githubusercontent.com/{REPO}/main/bucket/yazses.json"
     )
     if status != 200 or not data:
-        return False, f"bucket HTTP {status}"
+        return _verdict(status, False), f"bucket HTTP {status}"
     return data.get("version") == version, f"bucket={data.get('version')}"
 
 
-def check_winget(version: str) -> tuple[bool, str]:
+def check_winget(version: str) -> tuple[bool | None, str]:
     # The upstream community repo, not our own copy of the manifests. Having them
     # in packaging/ installs nobody.
     url = (
@@ -164,24 +195,24 @@ def check_winget(version: str) -> tuple[bool, str]:
         f"manifests/m/MSKazemi/YazSes/{version}"
     )
     status, _ = _get(url)
-    return status == 200, f"winget-pkgs HTTP {status}"
+    return _verdict(status, status == 200), f"winget-pkgs HTTP {status}"
 
 
-def check_chocolatey(version: str) -> tuple[bool, str]:
+def check_chocolatey(version: str) -> tuple[bool | None, str]:
     url = "https://community.chocolatey.org/api/v2/Packages()?$filter=Id%20eq%20'yazses'"
     status, body = _get(url)
     if status != 200:
-        return False, f"HTTP {status}"
+        return _verdict(status, False), f"HTTP {status}"
     text = body.decode("utf-8", "replace")
     return f"<d:Version>{version}</d:Version>" in text, (
         "listed" if "<entry>" in text else "not listed"
     )
 
 
-def check_aur(version: str) -> tuple[bool, str]:
+def check_aur(version: str) -> tuple[bool | None, str]:
     status, data = _json("https://aur.archlinux.org/rpc/v5/info?arg[]=yazses")
     if status != 200 or not data:
-        return False, f"AUR RPC HTTP {status}"
+        return _verdict(status, False), f"AUR RPC HTTP {status}"
     results = data.get("results", [])
     if not results:
         return False, "not in AUR"
@@ -189,35 +220,35 @@ def check_aur(version: str) -> tuple[bool, str]:
     return got.split("-")[0] == version, f"aur={got}"
 
 
-def check_flathub(version: str) -> tuple[bool, str]:
+def check_flathub(version: str) -> tuple[bool | None, str]:
     # The API answers honestly; flathub.org itself returns 200 for missing apps.
     status, _ = _get(f"https://flathub.org/api/v2/appstream/{FLATPAK_ID}")
-    return status == 200, f"appstream HTTP {status}"
+    return _verdict(status, status == 200), f"appstream HTTP {status}"
 
 
-def check_nix(version: str) -> tuple[bool, str]:
+def check_nix(version: str) -> tuple[bool | None, str]:
     # search.nixos.org is an SPA and lies. A raw path in nixpkgs does not.
     status, _ = _get(
         "https://raw.githubusercontent.com/NixOS/nixpkgs/master/"
         "pkgs/by-name/ya/yazses/package.nix"
     )
-    return status == 200, f"nixpkgs HTTP {status}"
+    return _verdict(status, status == 200), f"nixpkgs HTTP {status}"
 
 
-def check_docker(version: str) -> tuple[bool, str]:
+def check_docker(version: str) -> tuple[bool | None, str]:
     """GHCR needs a pull token even for public images; 401 is 'no such package'."""
     owner, image = REPO.split("/")
     status, tok = _json(
         f"https://ghcr.io/token?scope=repository:{owner.lower()}/{image}:pull&service=ghcr.io"
     )
     if status != 200 or not tok or "token" not in tok:
-        return False, f"token HTTP {status}"
+        return _verdict(status, False), f"token HTTP {status}"
     status, data = _json(
         f"https://ghcr.io/v2/{owner.lower()}/{image}/tags/list",
         {"Authorization": f"Bearer {tok['token']}"},
     )
     if status != 200 or not data:
-        return False, f"tags HTTP {status}"
+        return _verdict(status, False), f"tags HTTP {status}"
     tags = data.get("tags") or []
     return version in tags, f"tags={','.join(tags[:4]) or 'none'}"
 
@@ -259,7 +290,9 @@ def run(version: str, core_only: bool) -> list[Result]:
         try:
             ok, detail = fn(version)
         except Exception as e:  # a broken check must not hide the other thirteen
-            ok, detail = False, f"check errored: {type(e).__name__}"
+            # UNKNOWN, not False: a check that crashed has told us nothing about
+            # whether the package is published.
+            ok, detail = UNKNOWN, f"check errored: {type(e).__name__}"
         return Result(key, label, ok, detail, core=key in CORE)
 
     with ThreadPoolExecutor(max_workers=len(CHECKS)) as pool:
@@ -280,7 +313,12 @@ def main() -> int:
     args = ap.parse_args()
 
     results = run(args.version, args.core_only)
-    missing = [r for r in results if not r.ok]
+    # `is False` and `is None` are different answers and are reported separately.
+    # Rolling them together is what made one dropped connection to the AUR read as
+    # an unpublished package -- and "publish it again" is the wrong repair for a
+    # network blip.
+    missing = [r for r in results if r.ok is False]
+    unknown = [r for r in results if r.ok is UNKNOWN]
 
     if args.format == "json":
         print(json.dumps([r.__dict__ for r in results], indent=2))
@@ -289,14 +327,23 @@ def main() -> int:
         print("| Channel | Published | Detail |")
         print("|---|---|---|")
         for r in results:
-            print(f"| {r.label} | {'✅' if r.ok else '❌'} | {r.detail} |")
+            mark = "✅" if r.ok else ("⚠️" if r.ok is UNKNOWN else "❌")
+            print(f"| {r.label} | {mark} | {r.detail} |")
         print()
         if missing:
             print(f"**Missing ({len(missing)}):** " + ", ".join(r.label for r in missing))
-        else:
+        if unknown:
+            print(
+                f"**Could not check ({len(unknown)}):** "
+                + ", ".join(r.label for r in unknown)
+                + " — unreachable, not known to be absent."
+            )
+        if not missing and not unknown:
             print("**Every checked channel has this version.**")
 
-    return 1 if missing else 0
+    # Both are failures: one says a channel is behind, the other says we cannot
+    # prove it is not. Neither should be reported as a complete release.
+    return 1 if (missing or unknown) else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -281,11 +281,108 @@ def test_core_only_does_not_touch_the_other_channels(crc, responses):
 
 
 def test_full_run_covers_every_declared_channel(crc, responses):
-    responses({})  # everything absent
+    responses({}, default=(404, b""))  # everything genuinely absent
     results = crc.run("9.9.9", core_only=False)
     keys = {r.key for r in results}
     assert keys == {"deb", "dmg", "exe"} | {k for k, _, _ in crc.CHECKS}
     assert not any(r.ok for r in results)
+
+
+# --------------------------------------------------------------------------
+# Unreachable is not the same as absent
+# --------------------------------------------------------------------------
+
+
+def test_unreachable_host_is_unknown_not_absent(crc, responses):
+    """Status 0 means the request never completed.
+
+    Observed for real on 2026-08-13: one dropped connection to aur.archlinux.org
+    made the report say the AUR did not have the release, and three retries a
+    moment later all returned 200. Reporting that as absent invites the wrong
+    repair -- publishing a package that is already there.
+    """
+    responses({}, default=(0, b"Connection reset"))
+    for fn in (crc.check_aur, crc.check_pypi, crc.check_flathub, crc.check_snap):
+        ok, _ = fn("2.18.2")
+        assert ok is crc.UNKNOWN, f"{fn.__name__} reported {ok!r} for an unreachable host"
+
+
+def test_a_real_404_is_still_absent(crc, responses):
+    """The tri-state must not turn genuine absence into 'cannot tell'."""
+    responses({}, default=(404, b""))
+    assert crc.check_flathub("2.18.2")[0] is False
+    assert crc.check_pypi("2.18.2")[0] is False
+
+
+def test_release_assets_unreachable_is_unknown(crc, responses):
+    responses({}, default=(0, b"timeout"))
+    got = crc.check_release_assets("2.18.2")
+    assert all(ok is crc.UNKNOWN for ok, _ in got.values())
+    assert all("unreachable" in detail for _, detail in got.values())
+
+
+def test_transient_failure_is_retried_then_succeeds(crc, monkeypatch):
+    """Most status-0 failures are transient, so one blip must not decide the answer."""
+    calls = {"n": 0}
+
+    class Boom(Exception):
+        pass
+
+    def flaky(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise Boom("reset")
+
+        class R:
+            status = 200
+
+            def read(self):
+                return b"{}"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return R()
+
+    monkeypatch.setattr(crc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(crc.urllib.request, "urlopen", flaky)
+    status, _ = crc._get("https://example.invalid/x")
+    assert status == 200
+    assert calls["n"] == 2, "the first failure was not retried"
+
+
+def test_retries_give_up_and_report_zero(crc, monkeypatch):
+    def always_fail(req, timeout=None):
+        raise OSError("no route to host")
+
+    monkeypatch.setattr(crc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(crc.urllib.request, "urlopen", always_fail)
+    status, body = crc._get("https://example.invalid/x")
+    assert status == 0
+    assert b"no route" in body
+
+
+def test_unknown_is_reported_separately_from_missing(crc, responses, capsys, monkeypatch):
+    """The summary must not lump 'unreachable' in with 'not published'."""
+    responses(
+        {
+            "api.github.com": (
+                200,
+                _body({"assets": [{"name": "a.deb"}, {"name": "b.dmg"}, {"name": "c.exe"}]}),
+            )
+        },
+        default=(0, b"unreachable"),
+    )
+    monkeypatch.setattr(sys, "argv", ["prog", "--version", "2.18.2"])
+    code = crc.main()
+    out = capsys.readouterr().out
+    assert code == 1, "an unverifiable release must not be reported as complete"
+    assert "Could not check" in out
+    assert "not known to be absent" in out
+    assert "⚠️" in out
 
 
 def test_a_check_that_raises_does_not_hide_the_others(crc, responses, monkeypatch):
@@ -298,7 +395,8 @@ def test_a_check_that_raises_does_not_hide_the_others(crc, responses, monkeypatc
     monkeypatch.setattr(crc, "CHECKS", [("pypi", "PyPI", boom)])
     results = crc.run("2.18.2", core_only=False)
     pypi = next(r for r in results if r.key == "pypi")
-    assert pypi.ok is False
+    # UNKNOWN, not False: a crashed check has told us nothing about the package.
+    assert pypi.ok is crc.UNKNOWN
     assert "RuntimeError" in pypi.detail
     # The asset checks still reported.
     assert next(r for r in results if r.key == "deb").ok is True


### PR DESCRIPTION
Running the channel check against v2.18.2 reported **the AUR as not having the release**. It doesn't have it — but that was luck. The detail column read:

```
| AUR | ❌ | AUR RPC HTTP 0 |
```

`HTTP 0` is this script's code for *"the request never completed"*. Three curls to the same endpoint a moment later all returned **200**.

**One dropped connection and a channel is reported absent.**

## Why this matters more than a cosmetic bug

This is the same defect the whole session has been chasing — a failed query and a negative answer rendered identically — except now it's in the tool built to *detect* that class of problem. And it invites the worst possible repair: publishing a package that is already published.

It's the third instance today:

| Where | Failed query looked like |
|---|---|
| `checksums.yml` | `gh` couldn't resolve the repo → "assets not ready yet" → polled nothing for 40 min |
| `packaging/README.md` | GHCR 401 → "Docker unpublished" (it was live) |
| **here** | AUR connection reset → "not in AUR" |

## The fix

Every check gets a third answer:

- `True` — published
- `False` — the channel answered, and does not have it
- `None` — we could not ask

The table shows ⚠️ rather than ❌, the summary lists them separately as *"unreachable, not known to be absent"*, and **the exit code still fails** — an unverified release is not a verified one.

Transient failures are retried first, since most are. A check that *raises* also returns `None`: it has told us nothing about the package, and saying "absent" would be an invention.

## Verification

Live run after the change — the AUR now answers honestly:

```
| AUR | ❌ | not in AUR |          (was: ❌ AUR RPC HTTP 0)
Missing (5): winget-pkgs, Chocolatey, AUR, Flathub, nixpkgs
```

Tests: **28 passed** (6 new), still fully offline.

- an unreachable host is `UNKNOWN` for every channel, not `False`
- a real 404 is still `False` — the tri-state must not turn genuine absence into "cannot tell"
- a transient failure is retried and then succeeds
- retries give up and report 0
- the summary prints "Could not check" separately and exits 1

```
uv run python -m pytest tests/       3292 passed, 17 skipped
uv run ruff check src tests scripts  All checks passed!
```

## Note on winget

`microsoft/winget-pkgs#416963` is **open and pending review**, so winget's ❌ is accurate for "published" but understates reality. Distinguishing *submitted* from *absent* would need per-channel PR tracking — not attempted here.