### PR TITLE
fix: main is red — uv.lock never picked up noisereduce, so the SBOM drifted

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1470,6 +1470,19 @@
     },
     {
       "type": "library",
+      "name": "noisereduce",
+      "version": "3.0.3",
+      "purl": "pkg:pypi/noisereduce@3.0.3",
+      "bom-ref": "pkg:pypi/noisereduce@3.0.3",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ff64a28fb92e3c81f153cf29550e5c2db56b2523afa8f56f5e03c177cc5e918f"
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "numba",
       "version": "0.66.0",
       "purl": "pkg:pypi/numba@0.66.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2848,6 +2848,23 @@ wheels = [
 ]
 
 [[package]]
+name = "noisereduce"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/08/539e3cff148b7f9bde5b4b060451a7445d708fa3fe5d8a2bc0c552976e52/noisereduce-3.0.3.tar.gz", hash = "sha256:ff64a28fb92e3c81f153cf29550e5c2db56b2523afa8f56f5e03c177cc5e918f", size = 20968, upload-time = "2024-10-06T13:43:45.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/c5/fc00b3e8f86437039fb300ba41d5d683fdf0878d8782e827c2bad074eb59/noisereduce-3.0.3-py3-none-any.whl", hash = "sha256:95cb64cfe29b5fa0311ac764755d2f503ae71571040693577796412be1a54b9d", size = 22142, upload-time = "2024-10-06T13:43:43.886Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.66.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4330,8 +4347,6 @@ version = "0.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "python_version < '0'" },
-    { name = "python-xlib", marker = "python_version < '0'" },
     { name = "six" },
 ]
 wheels = [
@@ -6451,6 +6466,9 @@ ble = [
 chinese = [
     { name = "opencc-python-reimplemented" },
 ]
+denoise = [
+    { name = "noisereduce" },
+]
 desktop = [
     { name = "pyside6" },
 ]
@@ -6536,6 +6554,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'agent'", specifier = ">=1.28.1" },
     { name = "mediapipe", marker = "extra == 'all'", specifier = ">=0.10.35" },
     { name = "mediapipe", marker = "extra == 'gaze'", specifier = ">=0.10.35" },
+    { name = "noisereduce", marker = "extra == 'denoise'", specifier = ">=3.0.3" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "onnx-asr", extras = ["cpu", "hub"], marker = "extra == 'all'", specifier = ">=0.12" },
     { name = "onnx-asr", extras = ["cpu", "hub"], marker = "extra == 'parakeet'", specifier = ">=0.12" },
@@ -6578,7 +6597,7 @@ requires-dist = [
     { name = "speechbrain", marker = "extra == 'voiceprint'", specifier = ">=1.1" },
     { name = "typer", specifier = ">=0.26.8" },
 ]
-provides-extras = ["slm", "lsp", "emg", "ble", "overlay", "desktop", "prosody", "chinese", "tts", "voiceprint", "voiceprint-resemblyzer", "parakeet", "diarization", "diarization-pyannote", "notes", "silero", "agent", "gaze", "all"]
+provides-extras = ["slm", "lsp", "emg", "ble", "overlay", "desktop", "prosody", "chinese", "tts", "denoise", "voiceprint", "voiceprint-resemblyzer", "parakeet", "diarization", "diarization-pyannote", "notes", "silero", "agent", "gaze", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
`tests/test_sbom.py::test_committed_sbom_matches_the_lock_file` is **failing on `main`** (sha `49685aa`).

## Cause

The spectral-denoise work added `noisereduce` to `pyproject.toml`, but `uv.lock` was never regenerated. `uv lock --check` says so directly:

> The lockfile at `uv.lock` needs to be updated

## Why it does not reproduce locally — worth knowing

`gen-sbom.py` reads **`uv.lock` and nothing else**. Against the *committed* lock the SBOM is perfectly consistent, so the test **passes locally** on the exact sha CI failed on.

CI runs `uv sync` first, which updates the lockfile **in the runner**. The committed SBOM — generated from the old lock — then describes a dependency set that no longer matches.

So running just the generator produces an **empty diff** and looks like a no-op. I did exactly that first; it's a trap worth naming:

> A red `test_sbom` after a dependency change almost certainly means **`uv lock` was skipped**, not `gen-sbom.py`.

The test was right the whole time — both of its inputs were simply a step behind.

## Fix

```sh
uv lock                      # adds noisereduce v3.0.3, nothing else
python scripts/gen-sbom.py   # 275 -> 276 components
```

**This is not a dependency bump wearing a bugfix hat.** The lock diff is one package, 22 insertions, **zero transitive churn** — `+name = "noisereduce"` is the only package line that changes.

## Verification

- `uv lock --check` → clean
- `tests/test_sbom.py` → 7 passed
- full suite → **3368 passed, 17 skipped**
- `ruff check src tests scripts` → clean

Not my breakage — I merged #287 (two README files) five commits earlier — but `main` being red costs every session and every first-time visitor, and no one had a branch open for it.