### PR TITLE
fix(ci): two publish jobs that would have failed on the run that matters

### DIFF
--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -179,13 +179,16 @@ jobs:
             "https://x-access-token:${TAP_TOKEN}@github.com/MSKazemi/homebrew-yazses.git" tap
           cp packaging/homebrew/yazses.rb tap/Casks/yazses.rb
           cd tap
-          if git diff --quiet; then
+          git config user.name  "Mohsen Seyedkazemi Ardebili"
+          git config user.email "mohsen.seyedkazemi@gmail.com"
+          # Same reason as the AUR job: compare the index, not the worktree, so a
+          # cask that does not exist yet is a change rather than a silent no-op.
+          git add -A
+          if git diff --cached --quiet; then
             echo "tap already at $VERSION -- nothing to push."
             exit 0
           fi
-          git config user.name  "Mohsen Seyedkazemi Ardebili"
-          git config user.email "mohsen.seyedkazemi@gmail.com"
-          git commit -am "yazses $VERSION"
+          git commit -m "yazses $VERSION"
           git push
 
       - name: Explain the skip
@@ -224,14 +227,20 @@ jobs:
           cp packaging/arch/PKGBUILD packaging/arch/.SRCINFO aur/
           cp packaging/arch/yazses.install aur/ 2>/dev/null || true
           cd aur
-          if git diff --quiet; then
+          git config user.name  "Mohsen Seyedkazemi Ardebili"
+          git config user.email "mohsen.seyedkazemi@gmail.com"
+          # `git add -A` before comparing, and compare the INDEX. The first publish
+          # clones an empty repo, so PKGBUILD/.SRCINFO arrive untracked -- and
+          # `git diff` ignores untracked files. The previous form therefore reported
+          # "already up to date" and exited 0 having pushed nothing, on the one run
+          # that actually creates the package.
+          git add -A
+          if git diff --cached --quiet; then
             echo "AUR already at $VERSION -- nothing to push."
             exit 0
           fi
-          git config user.name  "Mohsen Seyedkazemi Ardebili"
-          git config user.email "mohsen.seyedkazemi@gmail.com"
-          git commit -am "yazses $VERSION"
-          git push
+          git commit -m "yazses $VERSION"
+          git push origin HEAD:master
 
       - name: Explain the skip
         if: env.HAVE_SECRET != 'yes'

--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -143,6 +143,18 @@ jobs:
             if ($errors) { Write-Error "$($_.Name): $($errors -join '; ')" }
             Write-Host "$($_.Name): parses OK"
           }
+          # Point the package at THIS release before packing. Nothing else
+          # regenerates it -- refresh-package-manifests.py covers only the
+          # Homebrew cask and the winget manifests -- so the nuspec version, the
+          # download URL and the checksum were all frozen at whatever was last
+          # committed. The next tag would have packed yazses.<old>.nupkg, and the
+          # push below would then fail on a filename that does not exist, while
+          # the install script still pointed at the previous release's .exe.
+          # The checksum comes from the SHA256SUMS.txt published on the release
+          # itself, so the package and the artifact cannot disagree.
+          python scripts/render-chocolatey.py $env:VERSION `
+            packaging/chocolatey/yazses.nuspec `
+            packaging/chocolatey/tools/chocolateyinstall.ps1
           choco pack packaging/chocolatey/yazses.nuspec --outputdirectory dist
           choco push "dist/yazses.$env:VERSION.nupkg" `
             --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY

--- a/scripts/render-chocolatey.py
+++ b/scripts/render-chocolatey.py
@@ -1,0 +1,54 @@
+"""Point the Chocolatey package at a specific release, deriving the checksum.
+
+Nothing regenerated the Chocolatey package: refresh-package-manifests.py covers
+only the Homebrew cask and the winget manifests. The nuspec version, the download
+URL and the checksum were all hardcoded, so the next tag would have packed
+`yazses.<old>.nupkg` (the push then fails on a filename that does not exist) while
+the install script still pointed at the previous release's .exe.
+
+The checksum is read from the SHA256SUMS.txt published on the release itself, so
+the package and the artifact cannot disagree.
+"""
+import re
+import sys
+import urllib.request
+
+REPO = "MSKazemi/yazses"
+
+
+def sha_for_exe(version: str) -> str:
+    url = f"https://github.com/{REPO}/releases/download/v{version}/SHA256SUMS.txt"
+    with urllib.request.urlopen(url, timeout=60) as r:
+        text = r.read().decode()
+    for line in text.splitlines():
+        digest, _, name = line.partition("  ")
+        if name.strip().endswith(".exe"):
+            return digest.strip()
+    raise SystemExit(f"no .exe line in SHA256SUMS.txt for v{version}:\n{text}")
+
+
+def main(version: str, nuspec: str, install: str) -> int:
+    sha = sha_for_exe(version)
+
+    s = open(nuspec, encoding="utf-8").read()
+    s, n = re.subn(r"<version>[^<]+</version>", f"<version>{version}</version>", s, count=1)
+    if n != 1:
+        raise SystemExit("could not find <version> in the nuspec")
+    open(nuspec, "w", encoding="utf-8").write(s)
+
+    p = open(install, encoding="utf-8").read()
+    exe = f"YazSes-{version}-windows-x64.exe"
+    p, a = re.subn(
+        r"(url64bit\s*=\s*')[^']+(')",
+        rf"\1https://github.com/{REPO}/releases/download/v{version}/{exe}\2", p, count=1)
+    p, b = re.subn(r"(checksum64\s*=\s*')[^']+(')", rf"\g<1>{sha}\2", p, count=1)
+    if a != 1 or b != 1:
+        raise SystemExit(f"install script rewrite failed (url={a} checksum={b})")
+    open(install, "w", encoding="utf-8").write(p)
+
+    print(f"chocolatey package set to {version}, checksum {sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
Found while checking that `packaging/arch` was ready to publish. **It is** — `pkgver=2.18.2` and a `sha256` that matches the PyPI sdist exactly (verified against `pypi.org/pypi/yazses/2.18.2/json`). The package was fine. The thing meant to publish it was not.

## The bug

The AUR job clones the package repo, copies `PKGBUILD` and `.SRCINFO` in, and skips the push when nothing changed:

```bash
cp packaging/arch/PKGBUILD packaging/arch/.SRCINFO aur/
cd aur
if git diff --quiet; then
  echo "AUR already at $VERSION -- nothing to push."
  exit 0
fi
```

On the **very first publish** that repo is empty, so both files arrive **untracked** — and `git diff --quiet` does not look at untracked files. It reports no change, the job prints *"already at 2.18.2 — nothing to push"*, and **exits 0 having created no package at all**.

The one run that matters is the one it silently skips. And it reports success while doing it.

## Demonstrated, not argued

```
-- OLD (git diff --quiet on an untracked file):
   says: NOTHING TO PUSH  <-- the bug
-- NEW (git add -A; git diff --cached --quiet):
   says: CHANGES TO PUSH  <-- correct
```

## Fix

- Compare the **index**: `git add -A` then `git diff --cached --quiet`.
- Push explicitly to `master` — the AUR expects that branch, and cloning a package that doesn't exist yet leaves the local branch at git's default, which is not necessarily the same name.
- **Same change in the Homebrew job**, for the same reason: a cask file that doesn't exist yet must count as a change, not a silent success.

## Status of the AUR channel

Everything on our side is ready. Blocked only on an AUR account + SSH key — and `aur.archlinux.org/register` is returning **503** right now (its package pages load fine, so registration specifically is down).