### PR TITLE
fix(tests): main is red — the PRIMARY-selection test needed xclip on the machine

### DIFF
--- a/tests/test_rewrite_command_mode.py
+++ b/tests/test_rewrite_command_mode.py
@@ -205,8 +205,23 @@ def test_a_refusal_says_the_text_was_left_alone():
 # ---- the clipboard read path ------------------------------------------------
 
 
-def test_read_selection_prefers_primary_then_clipboard():
-    from yazses.system.clipboard import read_selection
+def test_read_selection_prefers_primary_then_clipboard(monkeypatch):
+    """PRIMARY must be tried before CLIPBOARD — highlighting is the gesture.
+
+    The tool lookup is stubbed rather than inherited from the host. `read_selection`
+    builds its candidate commands with `shutil.which`, so on a machine without
+    xclip/xsel/wl-paste it produces *no* commands at all, the injected runner is
+    never called, and this test cannot see the ordering it exists to check. That is
+    not hypothetical: it passed on developer machines and failed on all six CI jobs,
+    because GitHub's runners ship none of those tools.
+
+    WAYLAND_DISPLAY is cleared for the same reason — otherwise the assertion would
+    exercise whichever of the two branches the host happens to be in.
+    """
+    from yazses.system import clipboard
+
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(clipboard.shutil, "which", lambda tool: f"/usr/bin/{tool}")
 
     calls = []
 
@@ -217,9 +232,20 @@ def test_read_selection_prefers_primary_then_clipboard():
         calls.append(cmd)
         return _R()
 
-    read_selection(runner=runner)
+    clipboard.read_selection(runner=runner)
+
+    assert calls, "no clipboard command was attempted at all"
     joined = " ".join(" ".join(c) for c in calls)
     assert "primary" in joined, "PRIMARY must be tried — highlighting is the gesture"
+
+    # Ordering is the actual invariant: PRIMARY has to be asked before CLIPBOARD,
+    # not merely somewhere in the list.
+    first_primary = next(i for i, c in enumerate(calls) if "primary" in " ".join(c))
+    clipboards = [i for i, c in enumerate(calls) if "clipboard" in " ".join(c)]
+    assert clipboards, "CLIPBOARD must still be tried as the fallback"
+    assert first_primary < clipboards[0], (
+        f"CLIPBOARD was tried before PRIMARY: {calls}"
+    )
 
 
 def test_get_clipboard_never_raises_on_a_broken_tool():


### PR DESCRIPTION
`test_read_selection_prefers_primary_then_clipboard` is failing on **all six** CI jobs on `main` (came in with `5e9474c`, Offline Command Mode).

**The feature is fine.** The test reaches out to the host.

## Cause

`_read_candidates()` only emits a command when the tool is actually installed:

```python
if shutil.which("xclip"): cmds.append(["xclip", "-selection", selection, "-o"])
if shutil.which("xsel"):  cmds.append(["xsel", f"--{selection}", "--output"])
```

GitHub's ubuntu, macOS and Windows runners ship **none** of `xclip`, `xsel`, `wl-paste`. So the candidate list is empty → the injected `runner` is never called → `calls` stays empty → the assertion cannot see the ordering it exists to check.

On a developer machine with `xclip` present it passes. That is exactly why it reached `main` green and went red on every runner simultaneously.

## Fix

Stub the tool lookup instead of inheriting it, and clear `WAYLAND_DISPLAY` so the test exercises one branch deterministically rather than whichever one the host happens to be in.

**Also tightened the assertion to the invariant it names.** `"primary" in joined` would be satisfied by asking CLIPBOARD *first* and PRIMARY second — the opposite of the contract. It now asserts the first PRIMARY call comes before the first CLIPBOARD call, and that a CLIPBOARD fallback is still attempted:

```python
first_primary = next(i for i, c in enumerate(calls) if "primary" in " ".join(c))
clipboards    = [i for i, c in enumerate(calls) if "clipboard" in " ".join(c)]
assert first_primary < clipboards[0]
```

## Verification

Simulated a runner with no clipboard tools (stubbing `shutil.which` → `None` for all three):

| | no tools present |
|---|---|
| original test | **FAILED** ← reproduces CI exactly |
| this test | **passed** |

Plus full suite **3472 passed, 17 skipped**, `ruff` clean.

## Pattern

Third instance today of *green locally, red in CI, because a test depends on its environment rather than its subject* — after `test_sbom` (needed `uv lock`, not `gen-sbom.py`) and the macOS manifest guards (silently skipped without `fetch-tags`).

Not my feature — flagging in case its author is already on it, in which case close this. But `main` has been red for a while and nothing was open against it.