### PR TITLE
feat(scripts): inspect a macOS .dmg from Linux, so the blind spot has a tool

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -153,6 +153,19 @@ log. `packaging/macos/yazses.spec` passes `target_arch=None`, which PyInstaller 
 as *host architecture*, not `universal2` despite what the comment there used to say.
 So the `.dmg` contains **no x86_64 slice and cannot launch on an Intel Mac.**
 
+Reproduce any of this yourself, on Linux, with no Mac and no `hdiutil`:
+
+```sh
+uv run python scripts/inspect-dmg.py YazSes-<version>.dmg \
+    --expect-version <version> --expect-arch arm64
+```
+
+It decodes the UDIF container `create-dmg` produces and reads the bundle's
+`Info.plist` and every Mach-O header out of the raw image. Both flags exit non-zero on
+a mismatch, so a release job can assert them — which is what would have caught the
+`0.1.2` version and the missing Intel slice years earlier. ⚠ It answers *"is the right
+thing inside the artefact"*, never *"does it launch"*; the second still needs a Mac.
+
 This was **verified against the artefact**, not only inferred from the runner. The
 `.dmg` that CI built for PR #263 was decompressed on Linux (UDIF/`koly` trailer → blkx
 block table → zlib chunks; no macOS tooling involved) and every Mach-O header in the

--- a/scripts/inspect-dmg.py
+++ b/scripts/inspect-dmg.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import base64
 import collections
+import json
 import plistlib
 import re
 import struct
@@ -170,6 +171,11 @@ def main(argv: list[str] | None = None) -> int:
         choices=sorted(set(CPU_TYPES.values())),
         help="fail unless every Mach-O slice is this architecture",
     )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the findings as JSON, for a release job to record or diff",
+    )
     args = ap.parse_args(argv)
 
     if not args.dmg.is_file():
@@ -183,6 +189,27 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: could not decode {args.dmg.name}: {exc}", file=sys.stderr)
         return 1
 
+    info = read_info_plist(image)
+    tally, fat = scan_macho(image)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "file": args.dmg.name,
+                    "compressed_bytes": len(data),
+                    "raw_bytes": len(image),
+                    "undecodable_chunks": skipped,
+                    "info_plist": info,
+                    "macho_slices": dict(tally),
+                    "fat_headers": fat,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return _verdict(args, info, tally, quiet=True)
+
     print(f"{args.dmg.name}: {len(data):,} bytes compressed -> {len(image):,} raw")
     if skipped:
         print(
@@ -190,7 +217,6 @@ def main(argv: list[str] | None = None) -> int:
             "decode (not zlib/raw); results may be incomplete"
         )
 
-    info = read_info_plist(image)
     if info:
         print("\nInfo.plist")
         for key in PLIST_KEYS:
@@ -201,11 +227,15 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("\n  WARNING: no Info.plist values found")
 
-    tally, fat = scan_macho(image)
     print("\nMach-O")
     print(f"  slices by CPU type             {dict(tally) or '{}'}")
     print(f"  universal/fat headers          {fat}")
 
+    return _verdict(args, info, tally, quiet=False)
+
+
+def _verdict(args, info: dict[str, str], tally, *, quiet: bool) -> int:
+    """Apply --expect-* and return the exit code. Shared by both output modes."""
     problems: list[str] = []
     if args.expect_version:
         actual = info.get("CFBundleShortVersionString")
@@ -222,12 +252,11 @@ def main(argv: list[str] | None = None) -> int:
             problems.append(f"no {args.expect_arch} slice found at all")
 
     if problems:
-        print()
         for p in problems:
             print(f"ERROR: {p}", file=sys.stderr)
         return 1
 
-    if args.expect_version or args.expect_arch:
+    if not quiet and (args.expect_version or args.expect_arch):
         print("\nOK — the bundle matches what was expected.")
         print("(Well-formed is not the same as running. That still needs a Mac.)")
     return 0

--- a/scripts/inspect-dmg.py
+++ b/scripts/inspect-dmg.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Inspect a macOS `.dmg` from Linux — no Mac, no `hdiutil`, no 7z.
+
+    uv run python scripts/inspect-dmg.py dist/YazSes-2.18.2.dmg
+    uv run python scripts/inspect-dmg.py YazSes.dmg --expect-version 2.18.2 --expect-arch arm64
+
+Why this exists
+---------------
+The project is developed on Linux and released for macOS, so the `.dmg` is the one
+artefact nobody here can open. That gap is not theoretical. Two defects lived in it
+for a long time and both were invisible until someone looked *inside* the shipped
+bundle rather than at the build that produced it:
+
+* every `.dmg` from v0.1.3 to v2.18.0 shipped an `.app` whose ``CFBundleVersion`` was
+  the literal string ``0.1.2`` — so Finder, ``mdls`` and any updater read an upgrade
+  as a downgrade;
+* the `.dmg` contains **no x86_64 slice at all** and cannot launch on an Intel Mac,
+  while the install docs promised "Apple Silicon or Intel".
+
+Neither is visible from CI logs: the build succeeds, the artefact is well formed, and
+the wrong value is inside it. `--expect-version` and `--expect-arch` turn both into a
+check that can run in a release job.
+
+What it does
+------------
+Decodes the UDIF container that `create-dmg` produces (`koly` trailer → XML plist →
+base64 `blkx` block tables → zlib chunks) into the raw disk image, then reads two
+things out of the bytes: the bundle's ``Info.plist`` and every Mach-O header.
+
+Deliberately stdlib-only, like `gen-sbom.py`, so it runs in a release job with
+nothing installed.
+
+Limits, stated plainly
+----------------------
+* Handles the **zlib (UDZO)** chunk type, which is what `create-dmg` emits by default,
+  plus raw and zero-fill runs. bzip2/LZFSE/ADC chunks are skipped, so a `.dmg` built
+  with other settings may decode partially — the tool says so rather than pretending.
+* Reading a well-formed bundle is **not** proof the app runs. It cannot be: that needs
+  a Mac. This answers "is the right thing inside the artefact", never "does it launch".
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import collections
+import plistlib
+import re
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+SECTOR = 512
+
+#: BLKX chunk entry types. See Apple's UDIF layout.
+CHUNK_ZERO = 0x00000000
+CHUNK_RAW = 0x00000001
+CHUNK_IGNORE = 0x00000002
+CHUNK_ZLIB = 0x80000005
+CHUNK_TERMINATOR = 0xFFFFFFFF
+
+#: Mach-O 64-bit little-endian magic, and the cputypes we care about.
+MACHO_MAGIC = b"\xcf\xfa\xed\xfe"
+FAT_MAGIC = b"\xca\xfe\xba\xbe"
+CPU_TYPES = {0x0100000C: "arm64", 0x01000007: "x86_64", 0x0000000C: "arm", 0x00000007: "i386"}
+#: MH_EXECUTE / MH_DYLIB / MH_BUNDLE — enough to reject random bytes that match the magic.
+FILE_TYPES = {2: "MH_EXECUTE", 6: "MH_DYLIB", 8: "MH_BUNDLE"}
+
+PLIST_KEYS = (
+    "CFBundleShortVersionString",
+    "CFBundleVersion",
+    "CFBundleIdentifier",
+    "LSMinimumSystemVersion",
+    "NSMicrophoneUsageDescription",
+)
+
+
+def read_koly(data: bytes) -> tuple[int, int]:
+    """Return (xml_offset, xml_length) from the 512-byte trailer."""
+    if len(data) < SECTOR:
+        raise ValueError("file is smaller than a UDIF trailer")
+    trailer = data[-SECTOR:]
+    if trailer[:4] != b"koly":
+        raise ValueError("no 'koly' trailer — not a UDIF .dmg")
+    xml_offset, xml_length = struct.unpack_from(">QQ", trailer, 0xD8)
+    return xml_offset, xml_length
+
+
+def inflate(data: bytes, xml_offset: int, xml_length: int) -> tuple[bytes, int]:
+    """Rebuild the raw disk image. Returns (image, skipped_chunk_count)."""
+    plist = plistlib.loads(data[xml_offset : xml_offset + xml_length])
+    out = bytearray()
+    skipped = 0
+
+    for entry in plist["resource-fork"]["blkx"]:
+        blob = entry["Data"]
+        table = blob if isinstance(blob, bytes) else base64.b64decode(blob)
+        if table[:4] != b"mish":
+            continue
+        start_sector = struct.unpack_from(">Q", table, 8)[0]
+        chunk_count = struct.unpack_from(">I", table, 200)[0]
+
+        for i in range(chunk_count):
+            off = 204 + i * 40
+            if off + 40 > len(table):
+                break
+            chunk_type, _comment, sector_number, sector_count, comp_off, comp_len = (
+                struct.unpack_from(">IIQQQQ", table, off)
+            )
+            if chunk_type == CHUNK_TERMINATOR:
+                break
+
+            pos = (start_sector + sector_number) * SECTOR
+            if len(out) < pos:
+                out.extend(b"\0" * (pos - len(out)))
+
+            if chunk_type == CHUNK_ZLIB:
+                piece = zlib.decompress(data[comp_off : comp_off + comp_len])
+            elif chunk_type == CHUNK_RAW:
+                piece = data[comp_off : comp_off + comp_len]
+            elif chunk_type in (CHUNK_ZERO, CHUNK_IGNORE):
+                piece = b"\0" * (sector_count * SECTOR)
+            else:
+                skipped += 1
+                continue
+            out[pos : pos + len(piece)] = piece
+
+    return bytes(out), skipped
+
+
+def read_info_plist(image: bytes) -> dict[str, str]:
+    """Pull the app bundle's Info.plist values straight out of the raw image.
+
+    The plist is XML on disk, so the values are greppable without walking HFS+.
+    """
+    found: dict[str, str] = {}
+    for key in PLIST_KEYS:
+        m = re.search(
+            rf"<key>{key}</key>\s*<string>([^<]*)</string>".encode(), image, re.S
+        )
+        if m:
+            found[key] = m.group(1).decode("utf-8", errors="replace").strip()
+    return found
+
+
+def scan_macho(image: bytes) -> tuple[collections.Counter, int]:
+    """Count Mach-O slices by CPU type. Returns (counter, fat_header_count)."""
+    tally: collections.Counter = collections.Counter()
+    for m in re.finditer(re.escape(MACHO_MAGIC), image):
+        off = m.start()
+        if off + 16 > len(image):
+            continue
+        _magic, cputype, _cpusub, filetype = struct.unpack_from("<IIII", image, off)
+        name = CPU_TYPES.get(cputype)
+        # Both filters matter: random bytes match a 4-byte magic surprisingly often.
+        if name is None or filetype not in FILE_TYPES:
+            continue
+        tally[name] += 1
+    return tally, len(re.findall(re.escape(FAT_MAGIC), image))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("dmg", type=Path)
+    ap.add_argument("--expect-version", help="fail unless CFBundleShortVersionString matches")
+    ap.add_argument(
+        "--expect-arch",
+        choices=sorted(set(CPU_TYPES.values())),
+        help="fail unless every Mach-O slice is this architecture",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.dmg.is_file():
+        print(f"ERROR: no such file: {args.dmg}", file=sys.stderr)
+        return 1
+
+    data = args.dmg.read_bytes()
+    try:
+        image, skipped = inflate(data, *read_koly(data))
+    except (ValueError, KeyError, zlib.error) as exc:
+        print(f"ERROR: could not decode {args.dmg.name}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"{args.dmg.name}: {len(data):,} bytes compressed -> {len(image):,} raw")
+    if skipped:
+        print(
+            f"  WARNING: {skipped} chunk(s) used a compression this tool does not "
+            "decode (not zlib/raw); results may be incomplete"
+        )
+
+    info = read_info_plist(image)
+    if info:
+        print("\nInfo.plist")
+        for key in PLIST_KEYS:
+            if key in info:
+                value = info[key]
+                shown = value if len(value) <= 60 else value[:57] + "..."
+                print(f"  {key:<30} {shown}")
+    else:
+        print("\n  WARNING: no Info.plist values found")
+
+    tally, fat = scan_macho(image)
+    print("\nMach-O")
+    print(f"  slices by CPU type             {dict(tally) or '{}'}")
+    print(f"  universal/fat headers          {fat}")
+
+    problems: list[str] = []
+    if args.expect_version:
+        actual = info.get("CFBundleShortVersionString")
+        if actual != args.expect_version:
+            problems.append(
+                f"CFBundleShortVersionString is {actual!r}, expected "
+                f"{args.expect_version!r}"
+            )
+    if args.expect_arch:
+        wrong = {a: n for a, n in tally.items() if a != args.expect_arch}
+        if wrong:
+            problems.append(f"unexpected architectures present: {wrong}")
+        if not tally.get(args.expect_arch):
+            problems.append(f"no {args.expect_arch} slice found at all")
+
+    if problems:
+        print()
+        for p in problems:
+            print(f"ERROR: {p}", file=sys.stderr)
+        return 1
+
+    if args.expect_version or args.expect_arch:
+        print("\nOK — the bundle matches what was expected.")
+        print("(Well-formed is not the same as running. That still needs a Mac.)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_inspect_dmg.py
+++ b/tests/test_inspect_dmg.py
@@ -152,3 +152,21 @@ def test_a_file_that_is_not_a_dmg_fails_cleanly(mod, tmp_path):
 
 def test_a_missing_file_fails_cleanly(mod, tmp_path):
     assert mod.main([str(tmp_path / "absent.dmg")]) == 1
+
+
+def test_json_mode_is_machine_readable_and_still_enforces_expectations(mod, tmp_path, capsys):
+    """A release job wants the findings recorded, not just a pass/fail."""
+    import json
+
+    raw = INFO_PLIST + b"\0" * 64 + _macho(0x0100000C)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw))
+
+    assert mod.main([str(dmg), "--json", "--expect-arch", "arm64"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["macho_slices"] == {"arm64": 1}
+    assert payload["info_plist"]["CFBundleShortVersionString"] == "2.18.2"
+    assert payload["undecodable_chunks"] == 0
+
+    # The expectations must gate the exit code in JSON mode too, not just in text mode.
+    assert mod.main([str(dmg), "--json", "--expect-arch", "x86_64"]) == 1

--- a/tests/test_inspect_dmg.py
+++ b/tests/test_inspect_dmg.py
@@ -1,0 +1,154 @@
+"""The .dmg inspector must work without a Mac, a fixture, or a network.
+
+`scripts/inspect-dmg.py` exists because the macOS bundle is the one artefact nobody
+here can open, and two defects hid in exactly that blind spot: an `.app` reporting
+``CFBundleVersion`` ``0.1.2`` for every release from v0.1.3 to v2.18.0, and a `.dmg`
+with no x86_64 slice while the docs promised Intel support.
+
+A fixture `.dmg` would be ~70 MB, so these build a **minimal UDIF container in
+memory** instead and round-trip it. That also tests the thing most likely to rot:
+the container parsing, not the greps.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import plistlib
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SECTOR = 512
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location(
+        "inspect_dmg", ROOT / "scripts" / "inspect-dmg.py"
+    )
+    m = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(m)
+    return m
+
+
+def _mish(chunks: list[tuple[int, int, int, bytes]], start_sector: int = 0) -> bytes:
+    """One BLKX block table. `chunks` are (type, sector_number, sector_count, payload)."""
+    table = bytearray(b"mish")
+    table += b"\0" * (8 - len(table))
+    table += struct.pack(">Q", start_sector)
+    table += b"\0" * (200 - len(table))
+    table += struct.pack(">I", len(chunks) + 1)
+
+    blobs = bytearray()
+    entries = bytearray()
+    # Payload offsets are absolute into the file; the caller places the data region
+    # right after the header, so track it as we go.
+    for ctype, sector_number, sector_count, payload in chunks:
+        entries += struct.pack(
+            ">IIQQQQ", ctype, 0, sector_number, sector_count, len(blobs), len(payload)
+        )
+        blobs += payload
+    entries += struct.pack(">IIQQQQ", 0xFFFFFFFF, 0, 0, 0, 0, 0)
+    return bytes(table + entries), bytes(blobs)
+
+
+def _build_dmg(image: bytes) -> bytes:
+    """Wrap a raw image in a minimal single-chunk zlib UDIF container."""
+    if len(image) % SECTOR:
+        image += b"\0" * (SECTOR - len(image) % SECTOR)
+    payload = zlib.compress(image)
+
+    # Data region first so the absolute offsets in the table are simply its position.
+    data_region = payload
+    table, _ = _mish([(0x80000005, 0, len(image) // SECTOR, payload)])
+    # Rewrite the single entry's compressed offset to point at the real location.
+    header_len = 204
+    entry = bytearray(table[header_len : header_len + 40])
+    struct.pack_into(">Q", entry, 24, 0)  # compressedOffset = start of file
+    table = table[:header_len] + bytes(entry) + table[header_len + 40 :]
+
+    plist = plistlib.dumps({"resource-fork": {"blkx": [{"Data": table}]}})
+    xml_offset = len(data_region)
+    trailer = bytearray(b"\0" * SECTOR)
+    trailer[0:4] = b"koly"
+    struct.pack_into(">QQ", trailer, 0xD8, xml_offset, len(plist))
+    return data_region + plist + bytes(trailer)
+
+
+INFO_PLIST = b"""<?xml version="1.0"?><plist><dict>
+<key>CFBundleShortVersionString</key><string>2.18.2</string>
+<key>CFBundleVersion</key><string>2.18.2</string>
+<key>CFBundleIdentifier</key><string>com.yazses.app</string>
+<key>LSMinimumSystemVersion</key><string>11.0</string>
+<key>NSMicrophoneUsageDescription</key><string>Mic is used only while held.</string>
+</dict></plist>"""
+
+
+def _macho(cputype: int, filetype: int = 2) -> bytes:
+    return b"\xcf\xfa\xed\xfe" + struct.pack("<III", cputype, 0, filetype)
+
+
+def test_round_trips_a_minimal_udif_container(mod, tmp_path):
+    raw = INFO_PLIST + b"\0" * 64 + _macho(0x0100000C)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw))
+
+    data = dmg.read_bytes()
+    image, skipped = mod.inflate(data, *mod.read_koly(data))
+    assert skipped == 0
+    assert INFO_PLIST in image
+
+
+def test_reads_the_bundle_version_and_architecture(mod, tmp_path):
+    raw = INFO_PLIST + b"\0" * 64 + _macho(0x0100000C) + _macho(0x0100000C, 6)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw))
+
+    assert mod.main([str(dmg), "--expect-version", "2.18.2", "--expect-arch", "arm64"]) == 0
+
+
+def test_a_wrong_version_is_an_error_not_a_note(mod, tmp_path):
+    """This is the 0.1.2 bug. It must fail the command, not print a remark."""
+    raw = INFO_PLIST.replace(b"<string>2.18.2</string>", b"<string>0.1.2</string>", 1)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw + b"\0" * 64 + _macho(0x0100000C)))
+
+    assert mod.main([str(dmg), "--expect-version", "2.18.2"]) == 1
+
+
+def test_an_x86_64_slice_is_caught_when_arm64_was_expected(mod, tmp_path):
+    raw = INFO_PLIST + b"\0" * 64 + _macho(0x0100000C) + _macho(0x01000007)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw))
+
+    assert mod.main([str(dmg), "--expect-arch", "arm64"]) == 1
+
+
+def test_expecting_an_arch_that_is_absent_fails(mod, tmp_path):
+    """The real defect's mirror image: docs promised Intel, the bundle had none."""
+    raw = INFO_PLIST + b"\0" * 64 + _macho(0x0100000C)
+    dmg = tmp_path / "T.dmg"
+    dmg.write_bytes(_build_dmg(raw))
+
+    assert mod.main([str(dmg), "--expect-arch", "x86_64"]) == 1
+
+
+def test_random_bytes_matching_the_magic_are_not_counted(mod):
+    """A 4-byte magic collides often; cputype and filetype must both be sane."""
+    noise = b"\xcf\xfa\xed\xfe" + struct.pack("<III", 0xDEADBEEF, 0, 99)
+    tally, fat = mod.scan_macho(noise)
+    assert tally == {} and fat == 0
+
+
+def test_a_file_that_is_not_a_dmg_fails_cleanly(mod, tmp_path):
+    p = tmp_path / "nope.dmg"
+    p.write_bytes(b"just some bytes" * 100)
+    assert mod.main([str(p)]) == 1
+
+
+def test_a_missing_file_fails_cleanly(mod, tmp_path):
+    assert mod.main([str(tmp_path / "absent.dmg")]) == 1


### PR DESCRIPTION
The `.dmg` is the one artefact **nobody working on this project can open**. Development is on Linux, CI only proves the build *succeeded*, and there is no `hdiutil`, `7z` or `dmg2img` here.

Two real defects lived in exactly that gap. Neither was visible from a build log, because the build was fine and the wrong value was *inside* the bundle:

- every `.dmg` from **v0.1.3 → v2.18.0** shipped an `.app` whose `CFBundleVersion` was the literal `0.1.2` — Finder and any updater read an upgrade as a downgrade
- the `.dmg` has **no `x86_64` slice at all** and cannot launch on an Intel Mac, while the install guide promised *"Apple Silicon or Intel"*

Both were found by hand-decoding the container. This makes that repeatable, and — the point — **assertable**:

```sh
uv run python scripts/inspect-dmg.py YazSes-2.18.2.dmg \
    --expect-version 2.18.2 --expect-arch arm64
```

Non-zero exit on mismatch, so a release job can gate on it. Either flag would have caught its defect years earlier.

## How

Decodes the UDIF container `create-dmg` emits — `koly` trailer → XML plist → base64 `blkx` block tables → zlib chunks — into the raw image, then reads the bundle's `Info.plist` and every Mach-O header out of the bytes. **Stdlib only**, like `gen-sbom.py`, so it runs in a release job with nothing installed.

## Verified against the real shipped v2.18.2 asset

```
Info.plist
  CFBundleShortVersionString     2.18.2
  CFBundleVersion                2.18.2
  LSMinimumSystemVersion         11.0
  NSMicrophoneUsageDescription   YazSes transcribes speech locally; the microphone is used...

Mach-O
  slices by CPU type             {'arm64': 122}
  universal/fat headers          0
```

## Tests

Build a **minimal UDIF container in memory** rather than committing a 70 MB fixture — so they exercise the container parsing, which is the part most likely to rot, not just the greps. 8 tests, and both real defects are pinned as failing cases:

- a `0.1.2` version where `2.18.2` was expected → exit 1
- an `x86_64` slice present when `arm64` was expected → exit 1
- expecting `x86_64` when the bundle has none → exit 1
- **magic-collision guard**: a 4-byte Mach-O magic matches random bytes often, so `cputype` *and* `filetype` must both be sane before a slice counts

## Two limits, stated up front rather than discovered later

1. Decodes **zlib/raw/zero** chunks — what `create-dmg` emits by default. It **says so** when it skips anything else, instead of silently reporting a partial image.
2. **A well-formed bundle is not a running app.** This answers *"is the right thing inside the artefact"*, never *"does it launch"*. That still needs a Mac, and is what the open macOS launch-test task asks for.

`ruff` clean · **3480 passed, 17 skipped**.
