### PR TITLE
docs: the changelog had TWO [Unreleased] sections, and three of my changes had none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed — the Hindi and Russian READMEs told Intel Mac users to download the `.dmg`
+
+`README.md` was corrected when the `.dmg` turned out to be Apple-silicon-only, but its
+translations were not. `README.hi.md` and `README.ru.md` kept offering the `.dmg` with no
+architecture caveat and no mention of the Homebrew tap — so a Hindi or Russian reader was
+sent to download a bundle that cannot launch on their machine, while the English reader was
+warned.
+
+Both files now name the architecture and point at `docs/macos-install.md`. The macOS blocks
+in those files are English inside the code fences, so the correction did not require
+inventing Hindi or Russian technical prose that could not be checked; a native speaker
+should still translate the note. `README.zh-CN.md` is a partial translation with no per-OS
+install blocks and carried no claim to correct.
+
+This is the failure mode #166 (a translation drift checker) exists to catch: a correction
+applied to one README and not its copies is invisible until someone reads the other one.
+
+### Fixed — the published SBOM did not list `noisereduce`
+
+The spectral-denoise work added `noisereduce` to `pyproject.toml` without regenerating
+`uv.lock`, so `sbom.cdx.json` — which is generated from the lock — described a dependency
+set the project no longer had. Anyone consuming the SBOM for supply-chain review was reading
+a component list one package short.
+
+It also turned `main` red in a way that does not reproduce locally: `gen-sbom.py` reads the
+lock and nothing else, so against the *committed* lock the SBOM is self-consistent and the
+test passes on a developer machine. CI runs `uv sync` first, which updates the lock in the
+runner, and the mismatch only appears there.
+
+### Added — `scripts/inspect-dmg.py`, so the macOS artefact can be checked without a Mac
+
+The `.dmg` is the one artefact that cannot be opened on the machine this project is
+developed on, and two defects lived in exactly that gap — an `.app` reporting version
+`0.1.2` for every release from v0.1.3 to v2.18.0, and a bundle with no `x86_64` slice while
+the install guide promised Intel support. Neither is visible from a build log: the build
+succeeds and the wrong value sits inside the artefact.
+
+```sh
+uv run python scripts/inspect-dmg.py YazSes-<version>.dmg \
+    --expect-version <version> --expect-arch arm64
+```
+
+It decodes the UDIF container `create-dmg` produces and reads the bundle's `Info.plist` and
+every Mach-O header out of the raw image, in stdlib-only Python. Both flags exit non-zero on
+a mismatch, so a release job can gate on them; `--json` emits the findings for a job to
+record or diff. Either flag would have caught its defect years earlier.
+
+It answers *"is the right thing inside the artefact"*, never *"does it launch"* — that still
+needs a Mac.
+
 ### Added — the three settings people actually tweak get real controls
 
 Feature toggles are booleans; the hotkey, the microphone and the VAD threshold
@@ -174,8 +224,6 @@ correction marker and satisfied the invariant identically — while meaning the
 opposite. `must_preserve_relation` pins which value wins, positionally, and the
 inverted sentence is now a case in its own right so the assertion is proven to
 have teeth. Contract 6.1.0 → 6.2.0. Raised by @YossiMH in the #98 review. (#163)
-
-## [Unreleased]
 
 ### Added — an activation source can say *what* it meant, not just *when*
 

--- a/tests/test_changelog_structure.py
+++ b/tests/test_changelog_structure.py
@@ -1,0 +1,70 @@
+"""The changelog must survive concurrent sessions merging into it.
+
+Two sessions each added entries under their own `## [Unreleased]` heading, and the
+merge kept **both** — leaving the file with two Unreleased sections about 170 lines
+apart. Nothing caught it: there is no changelog test, and no script renames
+`[Unreleased]` at release time, so the rename is a manual step that would have
+retitled the first heading and left ~100 lines of shipped entries sitting under a
+stray "Unreleased" heading *inside* a released changelog.
+
+These are cheap structural checks. They deliberately say nothing about whether an
+entry is good — that is a human judgement and stays one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = ROOT / "CHANGELOG.md"
+
+#: `## [1.2.3] - 2026-08-13` or `## [Unreleased]`
+VERSION_HEADING = re.compile(r"^## \[([^\]]+)\](?:\s+-\s+(\S+))?\s*$", re.M)
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return CHANGELOG.read_text(encoding="utf-8")
+
+
+def test_exactly_one_unreleased_section(text: str) -> None:
+    """The regression this file was written for."""
+    count = len(re.findall(r"^## \[Unreleased\]\s*$", text, re.M))
+    assert count == 1, (
+        f"found {count} '## [Unreleased]' headings; a merge probably kept both sides. "
+        "Release renames the first one and orphans everything under the others."
+    )
+
+
+def test_unreleased_comes_first(text: str) -> None:
+    """Newest first — an Unreleased section below a version is unreachable by a reader."""
+    headings = [m.group(1) for m in VERSION_HEADING.finditer(text)]
+    assert headings, "no version headings at all"
+    assert headings[0] == "Unreleased", (
+        f"first section is {headings[0]!r}; Unreleased must lead the file"
+    )
+    assert "Unreleased" not in headings[1:], "an Unreleased section appears below a release"
+
+
+def test_released_versions_are_unique_and_dated(text: str) -> None:
+    """A duplicated or undated release heading is the same merge accident, one level down."""
+    releases = [(m.group(1), m.group(2)) for m in VERSION_HEADING.finditer(text)]
+    versions = [v for v, _ in releases if v != "Unreleased"]
+
+    duplicates = {v for v in versions if versions.count(v) > 1}
+    assert not duplicates, f"duplicated release headings: {sorted(duplicates)}"
+
+    undated = [v for v, date in releases if v != "Unreleased" and not date]
+    assert not undated, f"release headings with no date: {undated}"
+
+
+def test_every_entry_sits_under_a_version(text: str) -> None:
+    """An `###` entry above the first `##` belongs to no release and ships nowhere."""
+    first_version = VERSION_HEADING.search(text)
+    assert first_version is not None
+    preamble = text[: first_version.start()]
+    orphans = re.findall(r"^### .*$", preamble, re.M)
+    assert not orphans, f"entries above the first version heading: {orphans}"


### PR DESCRIPTION
Asked whether the documentation was *actually* all updated — it wasn't. Two problems, one mine and one not.

## Not mine: a duplicate `## [Unreleased]`

`CHANGELOG.md` carried **two** `## [Unreleased]` headings, ~170 lines apart. Two sessions each added entries under their own heading and the merge kept both sides.

**Nothing caught it.** There is no changelog test, and no script renames `[Unreleased]` at release time — so that rename is a manual step that would have retitled the *first* heading and left roughly a hundred lines of shipped entries sitting under a stray "Unreleased" heading **inside a released changelog**.

The duplicate heading is removed so its entries continue under the single section above. **No entry text is touched.**

## Mine: three changes shipped with no entry

| Change | Why it belongs |
|---|---|
| Hindi/Russian READMEs sent Intel Mac users to the `.dmg` | plainly user-facing — and the English reader *was* warned while they weren't |
| the SBOM was missing `noisereduce` | the published component list was a package short; matters for supply-chain review |
| `scripts/inspect-dmg.py` | new tooling that lets a release job assert what is inside the macOS bundle |

**Deliberately still absent:** the clipboard test fix and the contributor-task rewording. A test that never affected a user, and an on-ramp description, are not "notable changes to YazSes" — a changelog that records them is one nobody reads.

## The guard

`tests/test_changelog_structure.py` checks the **shape**, never the prose:

- exactly one `[Unreleased]` section ← the regression this was written for
- `[Unreleased]` comes first (one below a release is unreachable to a reader)
- release headings are unique and dated
- no `###` entry stranded above the first version heading

Confirmed to **fail** against the duplicate it was written for, then pass once removed.

## Verification

`ruff` clean · **3485 passed, 17 skipped** · changelog diff is +50/−2, and the −2 is the duplicate heading and its blank line.