### PR TITLE
feat(scripts): Scoop and Arch were the two manifests nobody regenerated

### DIFF
--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -243,6 +243,10 @@ jobs:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
         run: |
           set -euo pipefail
+          # Regenerate from the release first, so a PKGBUILD nobody remembered to
+          # bump does not silently publish the previous version to the AUR. The
+          # guard below then only fires if that regeneration itself failed.
+          python3 scripts/refresh-package-manifests.py --version "$VERSION"
           # .SRCINFO is what the AUR actually indexes; a push without it, or with
           # one that disagrees with the PKGBUILD, is rejected.
           test -f packaging/arch/.SRCINFO

--- a/scripts/refresh-package-manifests.py
+++ b/scripts/refresh-package-manifests.py
@@ -41,6 +41,9 @@ REPO = "MSKazemi/yazses"
 ROOT = Path(__file__).resolve().parent.parent
 CASK = ROOT / "packaging" / "homebrew" / "yazses.rb"
 WINGET_DIR = ROOT / "packaging" / "winget" / "manifests" / "m" / "MSKazemi" / "YazSes"
+SCOOP = ROOT / "bucket" / "yazses.json"
+PKGBUILD = ROOT / "packaging" / "arch" / "PKGBUILD"
+SRCINFO = ROOT / "packaging" / "arch" / ".SRCINFO"
 
 # Inno Setup registers itself as "<AppId>_is1"; the AppId is fixed in
 # packaging/windows/installer.iss and must not change between versions, or winget
@@ -147,6 +150,48 @@ ManifestVersion: 1.6.0
     }
 
 
+def pypi_sdist_sha256(version: str) -> str:
+    """The Arch package builds from the PyPI sdist, not from a GitHub asset.
+
+    PyPI publishes the digest in its JSON API, so this needs no download -- which
+    also means the Arch manifests can be refreshed before the binaries finish
+    uploading.
+    """
+    url = f"https://pypi.org/pypi/yazses/{version}/json"
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310 - pypi.org only
+        data = json.load(resp)
+    for f in data.get("urls", []):
+        if f.get("packagetype") == "sdist":
+            return f["digests"]["sha256"]
+    raise SystemExit(f"yazses {version} has no sdist on PyPI -- cannot refresh the AUR package")
+
+
+def render_scoop(version: str, exe: Asset, previous: str) -> str:
+    """Rewrite only version/url/hash; the notes and bin/shortcut wiring are prose."""
+    data = json.loads(previous)
+    data["version"] = version
+    arch = data["architecture"]["64bit"]
+    arch["url"] = f"{exe.url}#/setup.exe"
+    arch["hash"] = exe.sha256
+    return json.dumps(data, indent=4) + "\n"
+
+
+def render_pkgbuild(version: str, sdist_sha: str, previous: str) -> str:
+    out = re.sub(r"^pkgver=.*$", f"pkgver={version}", previous, count=1, flags=re.M)
+    out = re.sub(r"^sha256sums=\(.*\)$", f"sha256sums=('{sdist_sha}')", out, count=1, flags=re.M)
+    return out
+
+
+def render_srcinfo(version: str, sdist_sha: str, previous: str) -> str:
+    out = re.sub(r"^(\tpkgver = ).*$", rf"\g<1>{version}", previous, count=1, flags=re.M)
+    out = re.sub(
+        r"^(\tsource = ).*$",
+        rf"\g<1>https://files.pythonhosted.org/packages/source/y/yazses/yazses-{version}.tar.gz",
+        out, count=1, flags=re.M)
+    out = re.sub(r"^(\tsha256sums = ).*$", rf"\g<1>{sdist_sha}", out, count=1, flags=re.M)
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("--version", required=True, help="release version, e.g. 2.17.0")
@@ -177,13 +222,28 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  {dmg.name}  {dmg.sha256}")
     print(f"  {exe.name}  {exe.sha256}")
 
+    sdist_sha = pypi_sdist_sha256(version)
+    print(f"  PyPI sdist                    {sdist_sha}")
+
     cask_text = render_cask(version, dmg, CASK.read_text(encoding="utf-8"))
     winget_files = render_winget(version, exe, release_date)
     winget_target = WINGET_DIR / version
+    # Scoop and Arch were hand-maintained and therefore drifted: at v2.18.2 both
+    # still pointed at an older release. The Scoop bucket is served straight out
+    # of this repository, so a stale manifest means `scoop update yazses` keeps
+    # installing the previous version indefinitely.
+    simple = {
+        SCOOP: render_scoop(version, exe, SCOOP.read_text(encoding="utf-8")),
+        PKGBUILD: render_pkgbuild(version, sdist_sha, PKGBUILD.read_text(encoding="utf-8")),
+        SRCINFO: render_srcinfo(version, sdist_sha, SRCINFO.read_text(encoding="utf-8")),
+    }
 
     if args.check:
         if CASK.read_text(encoding="utf-8") != cask_text:
             problems.append(f"{CASK.relative_to(ROOT)} is out of date")
+        for path, body in simple.items():
+            if path.read_text(encoding="utf-8") != body:
+                problems.append(f"{path.relative_to(ROOT)} is out of date")
         for filename, body in winget_files.items():
             path = winget_target / filename
             if not path.exists():
@@ -202,7 +262,10 @@ def main(argv: list[str] | None = None) -> int:
     winget_target.mkdir(parents=True, exist_ok=True)
     for filename, body in winget_files.items():
         (winget_target / filename).write_text(body, encoding="utf-8")
-    print(f"\nWrote {CASK.relative_to(ROOT)} and {winget_target.relative_to(ROOT)}/")
+    for path, body in simple.items():
+        path.write_text(body, encoding="utf-8")
+    written = ", ".join(str(p.relative_to(ROOT)) for p in simple)
+    print(f"\nWrote {CASK.relative_to(ROOT)}, {winget_target.relative_to(ROOT)}/, {written}")
     print(
         "The locale manifest carries prose, not checksums, so it is left alone —\n"
         "copy it from the previous version and edit the description if it changed."


### PR DESCRIPTION
`refresh-package-manifests.py` derived the Homebrew cask and the winget manifests and **stopped there**. The Scoop bucket and the Arch `PKGBUILD`/`.SRCINFO` were hand-maintained — which is exactly why both were found stale at 2.18.2.

## Scoop is the one that hurts

Its bucket is served **straight out of this repository**:

```
scoop bucket add yazses https://github.com/MSKazemi/yazses
```

So a manifest left behind means `scoop update yazses` keeps installing the **previous release indefinitely** — and the checksum still verifies, because it's the old file's checksum. Silent, and indistinguishable from working.

## What this derives

| Manifest | Digest source | Why |
|---|---|---|
| Scoop `bucket/yazses.json` | the `.exe` digest already computed for winget | same artifact |
| Arch `PKGBUILD` + `.SRCINFO` | **PyPI sdist**, via the JSON API | Arch builds from source, not the binary — and needs no download, so it can refresh before binaries finish uploading |

## Verified, not asserted

`--check` against **2.18.2** reproduces all five committed manifests **byte for byte** — proving the transforms are faithful and idempotent:

```
OK — every manifest matches the assets released as v2.18.2.
```

Rendering **2.18.0** then changes them correctly, cross-checked against independent sources:

| Value | Rendered | Authoritative |
|---|---|---|
| `.exe` sha256 | `d5d78e9d…757646a` | v2.18.0's published `SHA256SUMS.txt` ✅ |
| sdist sha256 | `6f29a1f1…fc5aab6` | PyPI JSON API ✅ |

## Also

The AUR publish job now runs the refresh **before** its staleness guard, so a `PKGBUILD` nobody remembered to bump can't quietly push the previous version. The guard now only fires if regeneration itself failed.

## Known remaining gap, stated plainly

**The Scoop bucket still needs committing back to `main` on a release.** It lives in the repo, so an ephemeral CI checkout can't fix it — the refresh helps the AUR and tap pushes, but not Scoop. That needs a commit-back step, which is a bigger change than this and deserves its own review.

## Gates

```
uv run python -m pytest tests/       3643 passed, 17 skipped, 1 xfailed
uv run ruff check src tests scripts  All checks passed!
all bash blocks                      bash -n clean
```