### PR TITLE
fix(ci): the winget job installed wingetcreate a way runners cannot

### DIFF
--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -127,11 +127,17 @@ jobs:
           if (-not (Test-Path $dir)) {
             Write-Error "no winget manifests for $env:VERSION at $dir -- run scripts/refresh-package-manifests.py first"
           }
-          winget install --id Microsoft.WingetCreate --exact --source winget `
-            --accept-package-agreements --accept-source-agreements
+          # Download the standalone exe rather than `winget install`. winget is a
+          # Store-delivered app and is not dependably present on a hosted Windows
+          # runner in a non-interactive session, so installing wingetcreate through
+          # it can fail before the submit is ever reached. Downloading the exe is
+          # the method winget-create's own README documents for pipelines.
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           # `submit` opens the PR against winget-pkgs from manifests we already
           # generate and validate in-repo, rather than re-deriving them here.
-          wingetcreate submit --token $env:WINGET_TOKEN $dir
+          .\wingetcreate.exe submit `
+            --prtitle "YazSes $env:VERSION" `
+            --token $env:WINGET_TOKEN $dir
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -27,7 +27,7 @@ the APT repo serves **2.18.2**, signed, `InRelease` 200.
 | **Nix** | ❌ 0 hits | `../flake.nix` | authored; **every nixpkgs attribute verified to exist**, but ⚠ **never evaluated** (no Nix here) ([#68](https://github.com/MSKazemi/yazses/issues/68)) |
 | **Docker/GHCR** | ✅ live | `docker/Dockerfile` | `ghcr.io/mskazemi/yazses:2.18.2` is **public and pullable** — now published on every tag ([#76](https://github.com/MSKazemi/yazses/issues/76)). ⚠ the earlier "404" was a **measurement error**: GHCR rejects unauthenticated reads, so a bare `curl` returns 401/404 for images that exist. Verify with a pull token, see below |
 | **Scoop** | ✅ live | `../bucket/yazses.json` | bucket served from this repo — `scoop bucket add yazses https://github.com/MSKazemi/yazses`; manifest at **2.18.2**, raw URL 200 ([#79](https://github.com/MSKazemi/yazses/issues/79)) |
-| **Chocolatey** | ❌ 404 | `chocolatey/` | nuspec + checksum verified; ⚠ **`.ps1` scripts not syntax-checked** (no `pwsh` on the authoring machine) |
+| **Chocolatey** | ❌ 404 | `chocolatey/` | nuspec + checksum verified; `.ps1` scripts **parse cleanly** (checked in `mcr.microsoft.com/powershell`), and the publish job re-parses them on a Windows runner before every push |
 
 > **Verification gotcha:** `curl -o /dev/null -w '%{http_code}'` **lies** about Flathub,
 > `search.nixos.org` and AlternativeTo — they are single-page apps that return **HTTP 200


### PR DESCRIPTION
Found by taking [[feedback_containers_are_the_missing_toolchain]] seriously — *"I don't have the toolchain" is almost never true.* There is no `pwsh` on this machine, so **both inline PowerShell blocks in `publish-channels.yml` shipped unverified**, and I said so in #285. A container parses them in seconds.

## The bug

The winget job ran:

```powershell
winget install --id Microsoft.WingetCreate --exact --source winget
```

**winget is a Store-delivered app** and is not dependably present on a hosted Windows runner in a non-interactive session. That step can fail *before* the submit it exists to perform is ever reached — so the first real winget publish would have died on tooling, not on anything to do with the package.

## The fix

`winget-create`'s own README documents the pipeline method — download the standalone exe:

```powershell
Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
.\wingetcreate.exe submit --prtitle "YazSes $env:VERSION" --token $env:WINGET_TOKEN $dir
```

Also adds `--prtitle`, so the PR opened against `winget-pkgs` is named rather than defaulted.

**The submit syntax itself was checked and is correct**: `submit --token <PAT> <PathToManifest>`, where the path may be the manifest directory.

## Verified in a container

```
mcr.microsoft.com/powershell → ParseFile
  OK   chocolatey.ps1
  OK   winget.ps1          (before AND after this change)
```

## A caveat that was never real

The same container settles something `packaging/README.md` has carried **for weeks**:

> ⚠ `.ps1` scripts not syntax-checked (no `pwsh` on the authoring machine)

Both Chocolatey scripts parse cleanly. The line is replaced with what is actually true — they parse, and the publish job re-parses them on a Windows runner before every push.

## Note

A parallel session already covered `rpmbuild`, `makepkg` and `nix` in containers and found a real defect in each. `pwsh` was the one left, and it was mine.