### PR TITLE
ci: check outbound links weekly, and report only the two statuses that mean gone

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,49 @@
+name: Outbound link check
+
+# Nothing checked outbound links, and it showed. `github.com/Sushanttmishraa` — the
+# credited native reviewer for the Hindi translation — had returned 404 on a
+# published page for an unknown length of time. That column is how the project
+# knows who to ask when the English README changes, so the status table was
+# pointing a maintainer at someone unreachable. It surfaced only because a human
+# swept all 334 links by hand once.
+#
+# SCHEDULED, NOT ON EVERY PUSH. These links rot on the *remote's* timetable, not
+# ours: an account is deleted, a paper moves, a vendor retires a page. Running it
+# per-push would spend CI minutes re-confirming the same 350 links and would make
+# an unrelated PR red for someone else's dead domain. Weekly catches it soon
+# enough for a docs site.
+#
+# ADVISORY BY DESIGN — `continue-on-error` on the job. A dead third-party link is
+# real but never urgent, and a checker that can block a merge on a remote host's
+# outage is one people route around. It reports; a human fixes.
+
+on:
+  schedule:
+    # Mondays, a little after the attribution check so the two summaries land together.
+    - cron: '43 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check
+  cancel-in-progress: true
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      # No dependencies on purpose: the script is stdlib-only, so this job needs
+      # no install step, no lockfile, and no third-party action with network
+      # access to the repo. Only `404` and `410` are reported — see the script's
+      # docstring for why every other status is deliberately ignored.
+      - name: Links that are definitively gone
+        run: python3 scripts/check-outbound-links.py

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ YazSes is a free, open-source, offline voice dictation and speech-to-text daemon
 
 ![yazses doctor — all green, fully offline by default](docs/screenshots/yazses-doctor.png)
 
-Prefer text over video? **[Watch the CLI in your browser](https://mskazemi.github.io/yazses/watch-the-cli.html)**
+Prefer text over video? **[Watch the CLI in your browser](https://mskazemi.com/yazses/watch-the-cli.html)**
 — an asciinema recording of the happy path (`-h` → `about` → `quickstart` → `features` →
 `status`), where every byte is real command output and nothing is hand-typed. The player is
 served from the docs site itself, not a CDN, so reading it does not report you to anyone.
@@ -123,7 +123,7 @@ and `pipx` paths install the last tagged release. YazSes is also on the
 **Just want to transcribe a recording?** There is a container for that — no install at
 all: `docker run --rm -v "$PWD:/data" ghcr.io/mskazemi/yazses transcribe /data/talk.m4a
 --diarize`. It does file→transcript with speaker labels and **not** hold-to-talk
-dictation, which needs a real desktop session; see [the Docker page](https://mskazemi.github.io/yazses/docker/).
+dictation, which needs a real desktop session; see [the Docker page](https://mskazemi.com/yazses/docker.html).
 
 > **Piping a script from the internet into your shell?** Fair. Add `--dry-run` and it
 > inspects your machine, prints every change it would make, and exits without making any

--- a/scripts/check-outbound-links.py
+++ b/scripts/check-outbound-links.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Report outbound links in the docs that are definitively gone.
+
+Nothing checked outbound links, and it showed: `github.com/Sushanttmishraa` — the
+credited **native reviewer** for the Hindi translation — returned 404 on a
+published page. That column is how the project knows who to ask when the English
+README changes, so the table was telling a maintainer to contact someone
+unreachable. It was found only because someone swept all 334 links by hand.
+
+## Why this reports so little
+
+The hard design problem for a link checker is not finding dead links; it is not
+crying wolf. A check that reports things a human then has to dismiss gets muted,
+and a muted check is worse than none, because its silence now means nothing.
+
+So only **404** and **410** fail. Everything else is deliberately ignored:
+
+- **403** is the single most common status from a real bibliography. Publishers
+  behind Cloudflare — ACM, Elsevier, Springer, Wiley, PNAS, NEJM — refuse any
+  client that is not a browser. In one sweep of this repo, 40+ citation links
+  answered 403 and *every one of them* was alive.
+- **429** is rate limiting, usually self-inflicted by the checker itself. The
+  first sweep here produced eight 429s from github.com purely from parallelism;
+  all eight were 200 when retried serially.
+- **5xx and timeouts** are the remote having a bad minute. A weekly check that
+  fails on those fails randomly forever.
+
+404 and 410 are the two the web actually means: this is not here, and this is
+gone on purpose. Both are worth a human's attention; nothing else is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: Files whose outbound links are checked. Deliberately the published surfaces —
+#: a dead link in a design note costs nothing; one in the docs site costs trust.
+SEARCH_GLOBS = ("docs/**/*.md", "README.md", "ROADMAP.md", "CONTRIBUTORS.md")
+
+#: Only these mean "this resource is not there". See the module docstring.
+DEAD = {404, 410}
+
+#: A real browser UA. Many hosts 403 anything that looks automated, and a 403 is
+#: not a finding here — but there is no reason to provoke one.
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+#: Hosts that are always placeholders, never resolvable. `example.com` is
+#: reserved by RFC 2606 exactly so documentation can use it.
+SKIP_HOSTS = {"example.com", "www.example.com", "example.org", "localhost"}
+
+_HTML_HREF = re.compile(r'href="(https?://[^"]+)"')
+_BARE = re.compile(r"<(https?://[^>]+)>")
+_MD_OPEN = re.compile(r"\]\((https?://)")
+
+
+def _markdown_urls(text: str) -> list[str]:
+    """Markdown link targets, counting parentheses instead of stopping at one.
+
+    A naive `\\((https?://[^\\s)]+)\\)` is wrong for this repo specifically, and
+    the checker caught it on its own first run: Elsevier DOIs embed a balanced
+    pair, so `10.1016/S0020-7373(86)80049-9` was truncated at `(86` and reported
+    as a 404. The full DOI resolves, and Python-Markdown renders it correctly —
+    the only broken thing was the extractor. A checker whose first report is a
+    phantom is exactly the one nobody trusts again.
+    """
+    urls = []
+    for match in _MD_OPEN.finditer(text):
+        start = match.start(1)
+        depth = 1
+        i = start
+        while i < len(text):
+            char = text[i]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            elif char.isspace():
+                # Markdown allows `[x](url "title")`; the title is not a link.
+                break
+            i += 1
+        urls.append(text[start:i])
+    return urls
+
+
+def extract_links(text: str) -> set[str]:
+    """Every outbound URL in one markdown file.
+
+    Covers the three forms the docs actually use: markdown links, raw HTML
+    `href=` (the contributor wall is generated HTML), and autolinks in angle
+    brackets (the citation blocks).
+    """
+    found: set[str] = set()
+    candidates = _markdown_urls(text)
+    for pattern in (_HTML_HREF, _BARE):
+        candidates.extend(pattern.findall(text))
+    for url in candidates:
+        # Strip a trailing fragment and any punctuation the prose leaked in.
+        url = url.split("#")[0].rstrip(".,;:")
+        if url:
+            found.add(url)
+    return found
+
+
+def collect(root: Path = ROOT) -> dict[str, set[str]]:
+    """url -> the repo-relative files that link to it."""
+    where: dict[str, set[str]] = {}
+    for glob in SEARCH_GLOBS:
+        for path in sorted(root.glob(glob)):
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for url in extract_links(text):
+                where.setdefault(url, set()).add(
+                    path.relative_to(root).as_posix()
+                )
+    return where
+
+
+def is_skipped(url: str) -> bool:
+    """Reserved documentation hosts are placeholders, not links."""
+    host = urllib.parse.urlsplit(url).hostname or ""
+    return host.lower() in SKIP_HOSTS
+
+
+def status_of(url: str, timeout: float = 25.0) -> int:
+    """HTTP status, following redirects. 0 means "could not tell" — never a finding."""
+    request = urllib.request.Request(url, headers={"User-Agent": UA}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except Exception:
+        # DNS failure, TLS problem, timeout, connection reset. Real breakage looks
+        # like this too, but so does a flaky runner, and we cannot tell them apart
+        # from one sample. Not a finding.
+        return 0
+
+
+@dataclass
+class Finding:
+    url: str
+    status: int
+    files: list[str]
+
+
+def check(where: dict[str, set[str]], workers: int = 8) -> list[Finding]:
+    urls = [u for u in sorted(where) if not is_skipped(u)]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        statuses = list(pool.map(status_of, urls))
+
+    dead = [(u, s) for u, s in zip(urls, statuses) if s in DEAD]
+    # Re-check serially before reporting. The parallel pass is what provokes rate
+    # limiting, and a 404 that becomes a 200 on a calm retry was never a finding.
+    findings = []
+    for url, _ in dead:
+        confirmed = status_of(url)
+        if confirmed in DEAD:
+            findings.append(Finding(url, confirmed, sorted(where[url])))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workers", type=int, default=8, help="parallel requests (default 8)"
+    )
+    args = parser.parse_args()
+
+    where = collect()
+    checked = sum(1 for u in where if not is_skipped(u))
+    print(f"checking {checked} outbound links across {len(SEARCH_GLOBS)} surfaces")
+
+    findings = check(where, workers=args.workers)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    if not findings:
+        print(f"OK - no dead links among {checked} checked")
+        if summary:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(f"No dead outbound links ({checked} checked).\n")
+        return 0
+
+    lines = [
+        "## Dead outbound links",
+        "",
+        "Only `404` and `410` are reported — a `403` from a publisher is a bot",
+        "block, not a dead link. Each of these was re-checked serially to rule out",
+        "rate limiting.",
+        "",
+        "| Status | URL | Linked from |",
+        "|---|---|---|",
+    ]
+    for f in findings:
+        lines.append(f"| {f.status} | {f.url} | {', '.join(f.files)} |")
+
+    report = "\n".join(lines)
+    print(report)
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_outbound_links.py
+++ b/tests/test_check_outbound_links.py
@@ -1,0 +1,168 @@
+"""`scripts/check-outbound-links.py` must be quiet about everything but real death.
+
+The value of this checker is entirely in what it *declines* to report. A link
+check that surfaces publisher bot-blocks gets muted within a week, and a muted
+check is worse than no check, because its silence then means nothing. So the
+status policy is the thing worth pinning, not the happy path.
+
+Fully offline, like the rest of the suite: every test drives the pure functions or
+stubs the one network seam (`status_of`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check-outbound-links.py"
+
+
+def _load():
+    """Import by path -- the filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("check_outbound_links", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+
+class TestExtractLinks:
+    def test_finds_markdown_links(self):
+        text = "see [the docs](https://example.net/a) for more"
+        assert mod.extract_links(text) == {"https://example.net/a"}
+
+    def test_finds_raw_html_href(self):
+        """The contributor wall is generated HTML, not markdown."""
+        text = '<a href="https://github.com/someone" title="Translation">x</a>'
+        assert mod.extract_links(text) == {"https://github.com/someone"}
+
+    def test_finds_autolinks(self):
+        """The citation blocks use angle-bracket autolinks."""
+        text = "Ardebili, M. (2026). <https://arxiv.org/abs/2607.28878>"
+        assert mod.extract_links(text) == {"https://arxiv.org/abs/2607.28878"}
+
+    def test_strips_the_fragment(self):
+        """A dead anchor is a different check; the resource is the same URL."""
+        text = "[x](https://example.net/page#section)"
+        assert mod.extract_links(text) == {"https://example.net/page"}
+
+    def test_strips_punctuation_the_prose_leaked_in(self):
+        text = "see <https://example.net/a>, and <https://example.net/b>."
+        assert mod.extract_links(text) == {
+            "https://example.net/a",
+            "https://example.net/b",
+        }
+
+    def test_keeps_balanced_parentheses_in_the_url(self):
+        """Elsevier DOIs embed a pair, and the naive regex truncated them.
+
+        Found by running this checker against the repo for the first time: it
+        reported `https://doi.org/10.1016/S0020-7373(86` as a 404. The real DOI
+        resolves and the page renders it correctly — only the extractor was
+        broken, which is the phantom finding that destroys trust in a checker.
+        """
+        text = "[doi:10.1016/S0020-7373(86)80049-9](https://doi.org/10.1016/S0020-7373(86)80049-9) — *measured*"
+        assert mod.extract_links(text) == {
+            "https://doi.org/10.1016/S0020-7373(86)80049-9"
+        }
+
+    def test_stops_at_a_markdown_link_title(self):
+        """`[x](url "title")` -- the title is not part of the URL."""
+        text = '[x](https://example.net/a "the title")'
+        assert mod.extract_links(text) == {"https://example.net/a"}
+
+    def test_ignores_relative_links(self):
+        """Internal links are mkdocs' job and are already checked by --strict."""
+        assert mod.extract_links("[x](../features.md) [y](#anchor)") == set()
+
+
+class TestStatusPolicy:
+    @pytest.mark.parametrize("status", [404, 410])
+    def test_only_these_are_dead(self, status):
+        assert status in mod.DEAD
+
+    @pytest.mark.parametrize(
+        "status,why",
+        [
+            (403, "Cloudflare bot block -- 40+ live citations answered 403"),
+            (429, "rate limiting, usually caused by the checker's own parallelism"),
+            (500, "the remote having a bad minute"),
+            (503, "maintenance"),
+            (0, "DNS/TLS/timeout -- indistinguishable from a flaky runner"),
+            (200, "alive"),
+            (301, "moved, and urllib followed it"),
+        ],
+    )
+    def test_everything_else_is_ignored(self, status, why):
+        assert status not in mod.DEAD, why
+
+
+class TestSkippedHosts:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/foo",
+            "https://www.example.com/",
+            "http://localhost:8000/x",
+        ],
+    )
+    def test_reserved_documentation_hosts_are_placeholders(self, url):
+        assert mod.is_skipped(url)
+
+    def test_real_hosts_are_not_skipped(self):
+        assert not mod.is_skipped("https://github.com/MSKazemi/yazses")
+
+
+class TestCheck:
+    def test_a_404_is_reported_with_the_files_that_link_it(self, monkeypatch):
+        monkeypatch.setattr(mod, "status_of", lambda url, **kw: 404)
+        where = {"https://example.net/gone": {"docs/a.md", "docs/b.md"}}
+        findings = mod.check(where, workers=2)
+        assert len(findings) == 1
+        assert findings[0].status == 404
+        assert findings[0].files == ["docs/a.md", "docs/b.md"]
+
+    def test_a_403_is_not_reported(self, monkeypatch):
+        monkeypatch.setattr(mod, "status_of", lambda url, **kw: 403)
+        assert mod.check({"https://dl.acm.org/doi/10.1145/x": {"docs/a.md"}}) == []
+
+    def test_a_parallel_404_that_recovers_serially_is_not_reported(self, monkeypatch):
+        """The serial re-check exists because the parallel pass provokes limits.
+
+        Eight github.com URLs answered 429 in the first real sweep purely from
+        concurrency and were all 200 when retried. The same shape can produce a
+        transient 404 behind a proxy, so a finding must survive a calm retry.
+        """
+        calls = {"n": 0}
+
+        def flaky(url, **kw):
+            calls["n"] += 1
+            return 404 if calls["n"] == 1 else 200
+
+        monkeypatch.setattr(mod, "status_of", flaky)
+        assert mod.check({"https://example.net/x": {"docs/a.md"}}) == []
+        assert calls["n"] == 2, "the serial re-check did not happen"
+
+    def test_skipped_hosts_are_never_requested(self, monkeypatch):
+        def explode(url, **kw):  # pragma: no cover - must not be called
+            raise AssertionError(f"requested a placeholder host: {url}")
+
+        monkeypatch.setattr(mod, "status_of", explode)
+        assert mod.check({"https://example.com/x": {"docs/a.md"}}) == []
+
+
+def test_the_published_surfaces_are_actually_covered():
+    """A glob that matches nothing passes silently -- the #63 lesson."""
+    collected = mod.collect()
+    assert collected, "collected no outbound links at all"
+    files = {f for files in collected.values() for f in files}
+    assert any(f.startswith("docs/") for f in files)
+    assert "README.md" in files


### PR DESCRIPTION
Follow-up to #312, kept separate because it is a different concern.

Nothing checked outbound links. `github.com/Sushanttmishraa` — the credited
**native reviewer** for the Hindi translation — had returned 404 on a published
page for an unknown length of time, and the localization table went on telling
maintainers to contact them whenever the English README changed. It surfaced only
because someone swept all 334 links by hand once. (The link itself is fixed in
#312; this is the thing that would have caught it.)

## The design problem is not finding dead links — it is not crying wolf

A check that reports things a human must then dismiss gets muted within a week,
and a muted check is worse than none, because its silence stops meaning anything.

So only **404** and **410** are reported. Everything else is deliberately ignored:

| Status | Why it is not a finding |
|---|---|
| `403` | Publisher bot-blocks. In one sweep here, **40+ citation links answered 403 and every one was alive** — ACM, Elsevier, Springer, Wiley, PNAS, NEJM. |
| `429` | Rate limiting, usually self-inflicted. Eight github.com URLs returned 429 from parallelism alone; all eight were 200 on a serial retry. |
| `5xx`, timeouts | The remote having a bad minute. Failing on these makes a weekly job fail randomly forever. |

Findings are re-checked **serially** before being reported, because the parallel
pass is what provokes rate limiting in the first place.

## Shape

- **Weekly, not per-push.** These rot on the *remote's* timetable. Per-push would
  re-confirm 355 links every time and make an unrelated PR red for someone else's
  dead domain.
- **`continue-on-error`.** A dead third-party link is real but never urgent, and a
  checker that can block a merge on a remote outage is one people route around.
- **Stdlib-only**, so the job needs no install step, no lockfile, and no
  third-party action with network access to the repo. Both pinned action SHAs are
  already used elsewhere in this repo — no new supply-chain surface.

## The first real run found a bug in the checker and two in the repo

**In the checker.** A naive `\((https?://[^\s)]+)\)` truncated
`10.1016/S0020-7373(86)80049-9` at `(86` and reported a phantom 404. Elsevier DOIs
embed a balanced pair; the full DOI resolves and Python-Markdown renders it
correctly — only the extractor was broken. Markdown targets are now scanned with
parenthesis depth-counting, stopping at whitespace so a `[x](url "title")` title
is not swallowed. A checker whose first report is a phantom is the one nobody
trusts again, so this mattered more than it looks.

**In the repo.** Two README links pointed at `mskazemi.github.io`, the retired
host. One redirects to the canonical domain and survived; `.../yazses/docker/` did
not — the site is built with `use_directory_urls: false`, so the page is
`docker.html` and a directory-style URL 404s on *both* hosts. Both now point at
`mskazemi.com` directly rather than leaning on a redirect.

## Verification

- End to end against `main`: reports **exactly one** finding — the known dead
  reviewer account — and exits 1. No phantoms.
- **26 offline unit tests** pin the status policy, the parenthesis case, the
  serial re-check, and that reserved placeholder hosts are never requested.
- Full suite `4356 passed, 17 skipped`.
