### PR TITLE
showcase: add macOS Homebrew test

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -31,4 +31,9 @@ Any setup is welcome — beginner or power user. 💛
   and long-form prose. The tray icon + mic-change auto-heal mean it "just works" even when a
   USB-C monitor tries to steal the mic. Tip: run `yazses mic-level --set` once after any mic change.
 
+### @hoti-code
+- **OS / desktop:** macOS (Apple silicon)
+- **Mic:** MacBook Air built-in microphone
+- **Apps you dictate into:** TextEdit
+- **How you use YazSes:** Tested the Homebrew cask install for #182. Installation and Gatekeeper override succeeded, but the app did not remain running, no YazSes menu-bar icon appeared, and macOS did not show Accessibility, Input Monitoring, or Microphone permission prompts. Holding the default Right Option hotkey produced no text in TextEdit. The bundled `doctor` reported keyboard capture and microphone access as denied.
 <!-- Add your entry above this line's section by appending a new ### block at the end. -->

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -35,5 +35,13 @@ Any setup is welcome — beginner or power user. 💛
 - **OS / desktop:** macOS (Apple silicon)
 - **Mic:** MacBook Air built-in microphone
 - **Apps you dictate into:** TextEdit
-- **How you use YazSes:** Tested the Homebrew cask install for #182. Installation and Gatekeeper override succeeded, but the app did not remain running, no YazSes menu-bar icon appeared, and macOS did not show Accessibility, Input Monitoring, or Microphone permission prompts. Holding the default Right Option hotkey produced no text in TextEdit. The bundled `doctor` reported keyboard capture and microphone access as denied.
+- **How you use YazSes:** Tested the Homebrew cask install for
+  [#182](https://github.com/MSKazemi/yazses/issues/182). Install and the Gatekeeper override
+  succeeded, but the app did not stay running, no menu-bar icon appeared, macOS showed no
+  Accessibility / Input Monitoring / Microphone prompt, the Right Option hotkey produced no
+  text, and `doctor` reported keyboard capture and microphone access denied.
+  **Diagnosis: the tap was serving 2.18.2** — frozen since 2026-08-13 because `TAP_TOKEN` was
+  never set — so this run predates both macOS fixes (`3bffc07`, `7b039fb`) and is not the
+  current build's behaviour. This report is what surfaced the frozen tap, which no dashboard
+  was reporting.
 <!-- Add your entry above this line's section by appending a new ### block at the end. -->


### PR DESCRIPTION
<!-- Thanks for contributing to YazSes! Keep this short — delete sections that don't apply. -->

## What does this PR do?

Adds my macOS Apple silicon Homebrew cask test result to `SHOWCASE.md`.

The cask installed successfully, but the app did not remain running, no YazSes menu-bar icon appeared, no expected macOS permission prompts were shown, and dictation into TextEdit did not work.


## Related issue

Refs #182 — kept OPEN: this run was on a stale (2.18.2) cask, so the macOS fixes remain unverified on hardware. 


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ x] Documentation
- [ ] Refactor / internal
- [ ] Build / CI / packaging

## How I tested it

TTested on:

- macOS 26.5.1 (Build 25F80)
- Apple M5
- Homebrew cask installation

Steps:
1. Installed YazSes using the Homebrew cask.
2. Manually bypassed Gatekeeper.
3. Launched `YazSes.app` from Finder.
4. Opened TextEdit.
5. Held the default Right Option hotkey for about 0.5–1 second, spoke a short phrase, and released it.
6. Ran:

```sh
/Applications/YazSes.app/Contents/MacOS/YazSes --cli doctor

Observed:
- No Accessibility permission prompt.
- No Input Monitoring permission prompt.
- No Microphone permission prompt.
- No YazSes menu-bar icon.
- No dictated text appeared in TextEdit.
- The app did not remain running.
- doctor reported keyboard capture and microphone access as denied.
- doctor also reported that version metadata was not found.

## AI assistance

Tool used: ChatGPT
What I verified personally:
- Homebrew cask installation
- Gatekeeper behaviour
- App launch behaviour
- macOS permission prompts
- Dictation attempt in TextEdit
- yazses doctor output

## Checklist

<!-- Docs-only PR (a translation, an example config, a typo, adding yourself to a list)?
     Tick the last three, ignore the rest and delete this comment — that is a complete PR
     and we will not ask you for tests. -->

- [ x] I have read every changed line and can explain why it is there
- [ ] Tests added or updated, and `uv run python -m pytest tests/ -v` passes locally
- [ ] Docs updated if behaviour, CLI, or config changed
- [ x] Change is cross-platform aware (Linux / macOS / Windows) where relevant
- [ x] The change is offline-first — no new network calls or telemetry
- [ x] No secrets, credentials, or personal data added

<!-- Nothing to sign. No CLA, no DCO, no sign-off line — Apache-2.0 section 5 covers the
     licence grant the moment you open this PR. -->


## Notes for reviewers

This PR only adds the macOS Homebrew test result to SHOWCASE.md.
The test exposed a runtime/permission issue rather than a documentation issue:
- installation succeeded
- Gatekeeper could be bypassed
- the app did not remain running
- expected permission prompts did not appear
- dictation did not work

