### PR TITLE
docs: add Dell Inspiron 15 3520 built-in to known-good microphones

### DIFF
--- a/docs/known-good-microphones.md
+++ b/docs/known-good-microphones.md
@@ -23,7 +23,7 @@ nothing here is tested by the maintainers.
 
 | Microphone | Type | OS / desktop | `vad_threshold` | Notes |
 |---|---|---|---|---|
-| _(your entry here)_ | | | | |
+| Dell Inspiron 15 3520 built-in | built-in | Ubuntu 24.04 LTS / GNOME (Wayland) | 0.010 | Clean speech capture at normal typing distance (~45–50 cm); default 0.010 threshold cleanly rejects ambient fan/room noise. |
 
 ## Add yours
 


### PR DESCRIPTION
## What does this PR do?

Adds the Dell Inspiron 15 3520 built-in microphone (CS8409/CS42L42 Analog) to `docs/known-good-microphones.md`.

## Related issue

Closes #21

## Type of change

- [x] Documentation

## How I tested it

Verified capture on Ubuntu 24.04 LTS / GNOME (Wayland) with PipeWire 1.0.5; default 0.010 `vad_threshold` provides clean speech capture at normal typing distance without triggering on room fan/ambient noise.

## Checklist

- [x] I have read every changed line and can explain why it is there
- [x] Change is cross-platform aware (Linux / macOS / Windows) where relevant
- [x] No secrets, credentials, or personal data added
