### PR TITLE
fix(windows): one IpcUnreachableError, and no SIGKILL where there is none (#330)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,7 +11,7 @@
   "commitConvention": "angular",
   "contributorsPerLine": 7,
   "contributorsSortAlphabetically": false,
-  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-22-orange.svg?style=flat-square)](#contributors)",
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-23-orange.svg?style=flat-square)](#contributors)",
   "contributors": [
     {
       "login": "MSKazemi",
@@ -233,6 +233,17 @@
       "contributions": [
         "doc",
         "userTesting"
+      ]
+    },
+    {
+      "login": "auroraxo",
+      "name": "Aurora",
+      "avatar_url": "https://avatars.githubusercontent.com/u/325296939?v=4",
+      "profile": "https://github.com/auroraxo",
+      "contributions": [
+        "code",
+        "test",
+        "platform"
       ]
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed — fourteen `except IpcUnreachableError:` handlers were dead code on Windows
+
+`yazses start` printed an `IpcUnreachableError` traceback while the daemon it was
+polling came up perfectly a second later, and `yazses restart` crashed outright on
+`signal.SIGKILL`. Reported by [@fall-water-zxc](https://github.com/fall-water-zxc)
+on two independent install routes, which is what ruled out Scoop as the cause
+([#330](https://github.com/MSKazemi/yazses/issues/330)); fixed by
+[@auroraxo](https://github.com/auroraxo) ([#360](https://github.com/MSKazemi/yazses/pull/360)).
+
+**Two classes had the same name and no relationship.** Every caller imports
+`IpcUnreachableError` from `yazses.ipc.client`; the named-pipe client raised a
+second, identically-named class declared in `yazses.platform.windows.ipc`. An
+exception is caught by identity, so the handler that exists specifically to mean
+"not up yet, keep polling" could not catch what the Windows transport threw. That
+is **fourteen** `except IpcUnreachableError:` sites in `cli.py` — `status`, `stop`,
+`doctor`, `logs` among them — plus `tray/app.py`, `mcp/server.py` and
+`platform/windows/lifecycle.py`: all of them graceful on Linux and macOS, all of
+them dead on Windows. It is a good explanation for why Windows felt rougher than
+the other two without anyone being able to point at why. The Windows class now
+subclasses the shared one and keeps its `pipe_name`, because an error that says
+"socket" on Windows is the sort of small lie that costs somebody an afternoon.
+
+**The `SIGKILL` guard was unreachable, not absent.** `_kill_yazses_daemons` opens
+with `if sys.platform != "linux": return 0`, but the call site read
+`_kill_yazses_daemons(signal.SIGKILL)` and Python evaluates the argument first —
+so the `AttributeError` fired before the guard could return, for the entire life of
+the guard. The signal is now resolved through `_force_kill_signal()`, which returns
+`None` where `signal` has no `SIGKILL`; `None` is a no-op, so no caller branches on
+the platform. It returns `None` rather than falling back to `SIGTERM` deliberately:
+the caller sent `SIGTERM` one second earlier, and a second `SIGTERM` is not a
+force-kill. A test asserts the Linux sequence is still `[SIGTERM, SIGKILL]`, so the
+fix cannot quietly weaken the path it was protecting.
+
+The stale `right_ctrl` hotkey in the same report was a *consequence* of the second
+bug rather than a third one: `restart` is the command that reloads the config, so a
+crashing `restart` leaves the old daemon and the old hotkey in place.
+
+Thirteen tests come with it, all running on Linux — the defects were Windows-only
+but their causes are plain Python, so nothing here needs Windows, pywin32, a named
+pipe or a daemon, and Windows' absence of `SIGKILL` is simulated with
+`monkeypatch.delattr`. Nine of them fail against the previous commit. Two are the
+generalisation added on merge: the reported bug was *a* transport shadowing a shared
+name, and nothing stopped the next one doing it again, so the region is now derived
+by globbing every `platform/*/ipc.py` rather than naming Windows — a new OS is
+covered the day its module appears.
+
 ### Fixed — the release-day guard that was right about the wrong bytes
 
 `docker.yml` waits for PyPI before building, because the image pins

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,6 +121,17 @@ found defects that no amount of reading the code here would have surfaced.
 - [@4nmus](https://github.com/4nmus) — Russian README translation, the project's first in
   Cyrillic script
 - [@AshSgDe29071999](https://github.com/AshSgDe29071999)
+- [@auroraxo](https://github.com/auroraxo) (Aurora) — found that **two different classes
+  called `IpcUnreachableError`** existed with no relationship between them, so the fourteen
+  `except IpcUnreachableError:` handlers in `cli.py` — plus the tray, the MCP server and the
+  Windows lifecycle — were dead code on Windows while behaving correctly on Linux and macOS
+  ([#330](https://github.com/MSKazemi/yazses/issues/330) →
+  [#360](https://github.com/MSKazemi/yazses/pull/360)). Also found the `SIGKILL` guard that
+  was *unreachable* rather than missing, because Python evaluates an argument before the
+  call that would have returned early. Both defects were Windows-only and both causes were
+  plain Python, and the thirteen tests that come with the fix prove them on Linux — including
+  the one that asserts the Linux force-kill sequence is unchanged, so a platform fix could not
+  quietly weaken the platform it was not about
 - [@fall-water-zxc](https://github.com/fall-water-zxc) — Windows 11 showcase entry:
   dictation into Notepad, the browser, the terminal and VS Code, with a laptop's
   built-in microphone and not sitting close to it

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Not sure yet? **[Try it without installing](https://mskazemi.com/yazses/try-with
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21856271.svg)](https://doi.org/10.5281/zenodo.21856271)
 [![Documentation](https://img.shields.io/badge/docs-mskazemi.com%2Fyazses-5e35b1)](https://mskazemi.com/yazses/)
 [![Open Source Helpers](https://www.codetriage.com/mskazemi/yazses/badges/users.svg)](https://www.codetriage.com/mskazemi/yazses)
-[![All Contributors](https://img.shields.io/badge/all_contributors-22-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-23-orange.svg?style=flat-square)](#contributors)
 
 [![Get it from the Snap Store](https://snapcraft.io/en/light/install.svg)](https://snapcraft.io/yazses) **X11 only — use the Linux installer on Wayland.**
 
@@ -722,6 +722,7 @@ Thanks to these people for helping build YazSes ✨ — every bug report, doc fi
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -92,6 +92,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/bn/index.md
+++ b/docs/bn/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/cs/index.md
+++ b/docs/cs/index.md
@@ -89,6 +89,7 @@ Zbytek dokumentace je zatím v angličtině.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -89,6 +89,7 @@ Die übrige Dokumentation ist derzeit auf Englisch.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/el/index.md
+++ b/docs/el/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -89,6 +89,7 @@ El resto de la documentación está por ahora en inglés.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/fa/index.md
+++ b/docs/fa/index.md
@@ -92,6 +92,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -89,6 +89,7 @@ Le reste de la documentation est pour l'instant en anglais.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/he/index.md
+++ b/docs/he/index.md
@@ -92,6 +92,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/hi/index.md
+++ b/docs/hi/index.md
@@ -603,6 +603,7 @@ Thanks to these people for helping build YazSes ✨ — every bug report, doc fi
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -89,6 +89,7 @@ Dokumentasi selebihnya untuk saat ini berbahasa Inggris.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -89,6 +89,7 @@ Il resto della documentazione è per ora in inglese.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/nl/index.md
+++ b/docs/nl/index.md
@@ -89,6 +89,7 @@ De rest van de documentatie is voorlopig in het Engels.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/pl/index.md
+++ b/docs/pl/index.md
@@ -89,6 +89,7 @@ Reszta dokumentacji jest na razie po angielsku.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -89,6 +89,7 @@ O restante da documentação está em inglês por enquanto.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -628,6 +628,7 @@ Thanks to these people for helping build YazSes ✨ — every bug report, doc fi
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -89,6 +89,7 @@ Resten av dokumentationen är på engelska tills vidare.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ta/index.md
+++ b/docs/ta/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/te/index.md
+++ b/docs/te/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/th/index.md
+++ b/docs/th/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/tr/index.md
+++ b/docs/tr/index.md
@@ -89,6 +89,7 @@ Belgelerin geri kalanı şimdilik İngilizcedir.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/uk/index.md
+++ b/docs/uk/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/ur/index.md
+++ b/docs/ur/index.md
@@ -92,6 +92,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/vi/index.md
+++ b/docs/vi/index.md
@@ -89,6 +89,7 @@ Phần tài liệu còn lại hiện vẫn bằng tiếng Anh.
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -262,6 +262,7 @@ yazses verify               # 说一句话，验证整条流水线确实可用
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/zh-TW/index.md
+++ b/docs/zh-TW/index.md
@@ -89,6 +89,7 @@ yazses start
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Akgithub2028"><img src="https://avatars.githubusercontent.com/u/181275449?v=4?s=100" width="100px;" alt="Aayaann Kausar"/><br /><sub><b>Aayaann Kausar</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=Akgithub2028" title="Documentation">📖</a> <a href="#userTesting-Akgithub2028" title="User Testing">📓</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/auroraxo"><img src="https://avatars.githubusercontent.com/u/325296939?v=4?s=100" width="100px;" alt="Aurora"/><br /><sub><b>Aurora</b></sub></a><br /><a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Code">💻</a> <a href="https://github.com/MSKazemi/yazses/commits?author=auroraxo" title="Tests">⚠️</a> <a href="#platform-auroraxo" title="Packaging/porting to new platform">📦</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/yazses/cli.py
+++ b/src/yazses/cli.py
@@ -954,18 +954,39 @@ def _main(
     pass
 
 
+def _force_kill_signal():
+    """The strongest available termination signal, or ``None`` where none is.
+
+    ``signal.SIGKILL`` is POSIX-only: Python's ``signal`` module does not define
+    it on Windows, so naming it there raises ``AttributeError``. ``_restart_daemon``
+    used to write ``_kill_yazses_daemons(signal.SIGKILL)``, and the argument is
+    evaluated *before* the call — so the ``sys.platform != "linux"`` guard inside
+    the function was unreachable on Windows and ``yazses restart`` crashed for the
+    whole life of the guard. Reported as #330.
+
+    Returning ``None`` rather than falling back to ``SIGTERM`` is deliberate: the
+    caller has already sent ``SIGTERM``, and a second one is not a force-kill.
+    """
+    import signal
+
+    return getattr(signal, "SIGKILL", None)
+
+
 def _kill_yazses_daemons(sig) -> int:
     """Linux: signal every yazses daemon process (systemd + detached `yazses.main`).
 
     Returns the count signalled. The detached `yazses start` path reparents to the
     systemd user manager and survives `systemctl stop`, so a clean restart must hunt
     them by command line, not just the PID file.
+
+    ``sig`` of ``None`` is a no-op, so a platform with no force-kill signal can call
+    this without the caller having to branch (see :func:`_force_kill_signal`).
     """
     import os
     import subprocess
     import sys
 
-    if sys.platform != "linux":
+    if sys.platform != "linux" or sig is None:
         return 0
     # Exclude this process AND the shell that launched us, so a command line that
     # happens to contain the pattern can never get itself killed.
@@ -1026,7 +1047,7 @@ def _restart_daemon(platform) -> None:
             pass
     _kill_yazses_daemons(signal.SIGTERM)
     time.sleep(1)
-    _kill_yazses_daemons(signal.SIGKILL)  # force any survivor
+    _kill_yazses_daemons(_force_kill_signal())  # force any survivor (no-op where unavailable)
     try:
         (platform.paths.data_dir / "daemon.lock").unlink(missing_ok=True)
     except Exception:

--- a/src/yazses/ipc/client.py
+++ b/src/yazses/ipc/client.py
@@ -19,9 +19,14 @@ class IpcCallError(RuntimeError):
 
 
 class IpcUnreachableError(IpcCallError):
-    """Raised when the daemon socket isn't listening."""
+    """Raised when the daemon socket isn't listening.
 
-    def __init__(self, socket_path: Path, cause: Exception | None = None) -> None:
+    ``socket_path`` is typed ``Path | str`` because it is only ever formatted
+    into the message, and the Windows transport's identifier is a named pipe
+    (``\\\\.\\pipe\\yazses-…``) rather than a filesystem path.
+    """
+
+    def __init__(self, socket_path: Path | str, cause: Exception | None = None) -> None:
         super().__init__(RpcError(code=NOT_REACHABLE, message=f"Daemon not reachable at {socket_path}"))
         self.socket_path = socket_path
         self.cause = cause

--- a/src/yazses/platform/windows/ipc.py
+++ b/src/yazses/platform/windows/ipc.py
@@ -17,11 +17,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from yazses.ipc.client import IpcCallError
+from yazses.ipc.client import IpcUnreachableError as _SharedIpcUnreachableError
 from yazses.ipc.protocol import (
     HANDLER_FAILED,
     INVALID_REQUEST,
     METHOD_NOT_FOUND,
-    NOT_REACHABLE,
     PARSE_ERROR,
     Request,
     Response,
@@ -191,19 +192,30 @@ class NamedPipeIpcServer:
         self._send(handle, Response(id=request_id, error=RpcError(code=code, message=message)))
 
 
-class IpcCallError(RuntimeError):
-    """Raised when an RPC call returns a JSON-RPC error."""
+class IpcUnreachableError(_SharedIpcUnreachableError):
+    """The daemon's named pipe isn't answering.
 
-    def __init__(self, error: RpcError) -> None:
-        super().__init__(f"[{error.code}] {error.message}")
-        self.error = error
+    This subclasses :class:`yazses.ipc.client.IpcUnreachableError` rather than a
+    second, identically-named class declared here, and that inheritance line is
+    load-bearing. Every caller in the codebase — all fourteen ``except
+    IpcUnreachableError:`` sites in ``cli.py``, plus ``tray/app.py``,
+    ``mcp/server.py`` and ``platform/windows/lifecycle.py`` — imports the name
+    from ``yazses.ipc.client``. While this module declared its own, those
+    handlers could not catch what this transport raised: ``yazses start``
+    reported ``IpcUnreachableError`` as an uncaught traceback while politely
+    polling a daemon that was coming up fine, and ``status``, ``stop``,
+    ``doctor`` and ``logs`` degraded gracefully on Linux and macOS and
+    tracebacked on Windows. Reported as #330.
 
+    ``pipe_name`` is kept alongside the inherited ``socket_path`` because the
+    Windows transport's identifier is a pipe name, not a filesystem path, and
+    an error message that says "socket" on Windows is the sort of small lie
+    that costs somebody an afternoon.
+    """
 
-class IpcUnreachableError(IpcCallError):
     def __init__(self, pipe_name: str, cause: Exception | None = None) -> None:
-        super().__init__(RpcError(code=NOT_REACHABLE, message=f"Daemon not reachable at {pipe_name}"))
+        super().__init__(pipe_name, cause=cause)
         self.pipe_name = pipe_name
-        self.cause = cause
 
 
 class NamedPipeIpcClient:

--- a/tests/test_windows_daemon_lifecycle_330.py
+++ b/tests/test_windows_daemon_lifecycle_330.py
@@ -1,0 +1,237 @@
+"""Windows daemon lifecycle: #330 — the two bugs that made `start` and `restart` fail.
+
+Both are cross-platform-testable on Linux, which matters: the defects lived only on
+Windows but their *causes* are plain Python — an exception hierarchy and an argument
+evaluated before the guard that was meant to protect it — so nothing here needs
+Windows, pywin32, a named pipe or a daemon.
+
+## Bug 1 — `yazses start` reported an IPC failure for a daemon that started fine
+
+`cli._wait_until_ready` polls the daemon and swallows the one error it expects:
+
+    except IpcUnreachableError:
+        pass  # IPC socket not up yet — keep polling
+
+That `except` never fired on Windows. There were **two different classes with the
+same name** — `yazses.ipc.client.IpcUnreachableError` (imported by every caller)
+and a second one declared in `yazses.platform.windows.ipc` (raised by the pipe
+client) — with no inheritance between them. The raised error sailed past the
+handler and out as a traceback, while the daemon came up a second later.
+
+`cli.py` has fourteen `except IpcUnreachableError:` sites; `tray/app.py`,
+`mcp/server.py` and `platform/windows/lifecycle.py` have more. Every one of them
+was dead code on Windows, which is a good explanation for why Windows felt rougher
+than Linux and macOS without anyone being able to say why.
+
+## Bug 2 — `yazses restart` crashed on `signal.SIGKILL`
+
+`_kill_yazses_daemons` has a `sys.platform != "linux"` guard, but the call site
+read `_kill_yazses_daemons(signal.SIGKILL)` and Python evaluates the argument
+first. `signal.SIGKILL` is POSIX-only and does not exist on Windows, so the
+`AttributeError` was raised *before* the guard could return. The guard was
+unreachable on Windows for its entire life.
+
+The stale-hotkey symptom in #330 is a consequence of this one, not a third bug:
+`restart` is the command that reloads the config, so a crashing `restart` leaves
+the old daemon — and the old hotkey — in place.
+"""
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+import yazses.cli as cli
+from yazses.ipc.client import IpcCallError, IpcUnreachableError
+from yazses.ipc.protocol import NOT_REACHABLE
+from yazses.platform.windows import ipc as win_ipc
+
+# ---- Bug 1: one exception hierarchy, not two ------------------------------
+
+
+def test_windows_unreachable_is_catchable_as_the_shared_one():
+    """The single assertion that was False and is the whole of bug 1."""
+    assert issubclass(win_ipc.IpcUnreachableError, IpcUnreachableError)
+
+
+def test_windows_unreachable_is_also_an_ipc_call_error():
+    """`except IpcCallError:` sites must catch it too — several only catch the base."""
+    assert issubclass(win_ipc.IpcUnreachableError, IpcCallError)
+
+
+def test_windows_module_does_not_redeclare_the_shared_call_error():
+    """Re-declaring `IpcCallError` here is what split the hierarchy in the first place."""
+    assert win_ipc.IpcCallError is IpcCallError
+
+
+def test_catching_the_shared_name_catches_the_windows_error():
+    """The handler shape from cli.py, tray/app.py and mcp/server.py, verbatim."""
+    try:
+        raise win_ipc.IpcUnreachableError(r"\\.\pipe\yazses-alice-daemon")
+    except IpcUnreachableError as exc:
+        assert "yazses-alice-daemon" in str(exc)
+    else:  # pragma: no cover - the assertion above is the point
+        pytest.fail("the shared handler did not catch the Windows transport's error")
+
+
+def test_windows_error_keeps_its_pipe_name_and_cause():
+    """Subclassing must not cost the transport-specific detail callers log."""
+    cause = OSError("WaitNamedPipe: The system cannot find the file specified.")
+    exc = win_ipc.IpcUnreachableError(r"\\.\pipe\yazses-bob-daemon", cause=cause)
+    assert exc.pipe_name == r"\\.\pipe\yazses-bob-daemon"
+    assert exc.cause is cause
+    assert exc.error.code == NOT_REACHABLE  # unchanged by the reparenting
+
+
+def test_wait_until_ready_keeps_polling_through_a_windows_pipe_error():
+    """End-to-end on the code path from the report: `start` must not raise.
+
+    Before the fix this propagated out of `_wait_until_ready` as the traceback
+    users saw, instead of being swallowed as "not up yet".
+    """
+
+    class _Lifecycle:
+        def __init__(self):
+            self._running = [True, True]
+
+        def is_running(self):
+            return self._running.pop(0) if self._running else True
+
+    class _Client:
+        def __init__(self):
+            self._responses = [
+                win_ipc.IpcUnreachableError(r"\\.\pipe\yazses-carol-daemon"),
+                {"state": "idle", "ready": True},
+            ]
+
+        def call(self, _method, **_params):
+            item = self._responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+    class _Paths:
+        ipc_socket = "ignored"
+
+    class _Platform:
+        def __init__(self):
+            self.lifecycle = _Lifecycle()
+            self.paths = _Paths()
+            self._client = _Client()
+
+        def ipc_client_factory(self, _socket):
+            return self._client
+
+    outcome, info = cli._wait_until_ready(_Platform(), timeout=5.0)
+    assert outcome == "ready"
+    assert info["ready"] is True
+
+
+# ---- Bug 2: no SIGKILL where there is no SIGKILL --------------------------
+
+
+def test_force_kill_signal_is_sigkill_on_posix():
+    assert cli._force_kill_signal() is signal.SIGKILL
+
+
+def test_force_kill_signal_is_none_where_the_attribute_is_absent(monkeypatch):
+    """Simulate Windows by removing the attribute Windows does not have."""
+    monkeypatch.delattr(signal, "SIGKILL", raising=True)
+    assert cli._force_kill_signal() is None
+
+
+def test_kill_yazses_daemons_treats_none_as_a_no_op(monkeypatch):
+    """So the caller never has to branch on the platform."""
+    import subprocess
+
+    def _boom(*_a, **_k):  # pragma: no cover - must not be reached
+        pytest.fail("a None signal must not reach pgrep")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert cli._kill_yazses_daemons(None) == 0
+
+
+def test_restart_does_not_touch_sigkill_on_a_platform_without_it(monkeypatch):
+    """The regression test for the traceback in #330.
+
+    With `signal.SIGKILL` absent, `_restart_daemon` previously raised
+    `AttributeError: module 'signal' has no attribute 'SIGKILL'` at the call
+    site, before its own platform guard could return — so `restart` crashed and
+    the daemon was left running with the *old* config, which is the stale
+    `right_ctrl` hotkey the reporter saw.
+    """
+    monkeypatch.delattr(signal, "SIGKILL", raising=True)
+    monkeypatch.setattr(cli, "_systemd_managed", lambda: False)
+    monkeypatch.setattr(cli, "_kill_yazses_daemons", lambda _sig: 0)
+
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_: None)
+
+    spawned = []
+    monkeypatch.setattr(cli, "_spawn_daemon", lambda plat: spawned.append(plat))
+
+    class _Paths:
+        def __init__(self, tmp):
+            self.data_dir = tmp
+
+    class _Lifecycle:
+        def __init__(self):
+            self.cleared = 0
+
+        def read_pid(self):
+            return None
+
+        def clear_pid(self):
+            self.cleared += 1
+
+    class _Platform:
+        def __init__(self, tmp):
+            self.lifecycle = _Lifecycle()
+            self.paths = _Paths(tmp)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plat = _Platform(Path(tmp))
+        cli._restart_daemon(plat)  # must not raise
+
+    assert plat.lifecycle.cleared == 1
+    assert spawned == [plat], "restart must still end with exactly one daemon spawned"
+
+
+def test_restart_still_force_kills_on_posix(monkeypatch):
+    """The fix must not quietly weaken the Linux path it was protecting."""
+    monkeypatch.setattr(cli, "_systemd_managed", lambda: False)
+    sent = []
+    monkeypatch.setattr(cli, "_kill_yazses_daemons", lambda sig: sent.append(sig) or 0)
+
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_: None)
+    monkeypatch.setattr(cli, "_spawn_daemon", lambda _plat: None)
+
+    class _Paths:
+        def __init__(self, tmp):
+            self.data_dir = tmp
+
+    class _Lifecycle:
+        def read_pid(self):
+            return None
+
+        def clear_pid(self):
+            return None
+
+    class _Platform:
+        def __init__(self, tmp):
+            self.lifecycle = _Lifecycle()
+            self.paths = _Paths(tmp)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cli._restart_daemon(_Platform(Path(tmp)))
+
+    assert sent == [signal.SIGTERM, signal.SIGKILL]

--- a/tests/test_windows_daemon_lifecycle_330.py
+++ b/tests/test_windows_daemon_lifecycle_330.py
@@ -235,3 +235,79 @@ def test_restart_still_force_kills_on_posix(monkeypatch):
         cli._restart_daemon(_Platform(Path(tmp)))
 
     assert sent == [signal.SIGTERM, signal.SIGKILL]
+
+
+# ---- The general form: no platform transport may shadow a shared IPC name ----
+#
+# The two assertions above name `platform.windows.ipc` explicitly, which locks
+# the bug that was reported and nothing else. But the defect was never really
+# "Windows declared a class"; it was that **an exception is caught by identity**,
+# so any transport that re-declares a name its callers import from
+# `yazses.ipc.client` silently disables every `except` site for that platform —
+# with no import error, no lint warning and no failing test to say so.
+#
+# `platform/linux/ipc.py` and `platform/macos/ipc.py` cannot hit this today
+# because they reuse `JsonRpcClient` and therefore raise the shared errors by
+# construction. That is a property of how they happen to be written, not a rule
+# anything enforces, and the next transport (a BSD one, a socket-activated one,
+# a test double) gets no warning at all.
+#
+# So derive the region rather than listing it: every `ipc.py` under
+# `platform/`, discovered by glob, is checked against every public name in
+# `yazses.ipc.client`. A new OS is covered the day its module appears.
+
+
+def _platform_ipc_modules():
+    """Every platform IPC module, found by globbing rather than by memory."""
+    import importlib
+    from pathlib import Path
+
+    import yazses.platform as platform_pkg
+
+    root = Path(platform_pkg.__file__).parent
+    found = {}
+    for path in sorted(root.glob("*/ipc.py")):
+        name = f"yazses.platform.{path.parent.name}.ipc"
+        found[name] = importlib.import_module(name)
+    return found
+
+
+def test_the_platform_ipc_module_scan_finds_something():
+    """A guard that iterates is green on an empty collection.
+
+    If the glob ever stops matching -- a rename, a package move, a layout
+    change -- the shadowing test below would pass by checking nothing. Fail
+    here instead, loudly, rather than reporting compliance we did not verify.
+    """
+    modules = _platform_ipc_modules()
+    assert len(modules) >= 3, f"expected linux/macos/windows IPC modules, found {sorted(modules)}"
+
+
+def test_no_platform_transport_shadows_a_shared_ipc_name():
+    """A platform module may subclass a shared IPC name, never redeclare it.
+
+    This is the generalisation of #330: `windows.ipc` declared its own
+    `IpcUnreachableError`, unrelated by inheritance to the one all fourteen
+    `except` sites in `cli.py` import, so those handlers were dead code on
+    Windows while behaving correctly on Linux and macOS.
+    """
+    import yazses.ipc.client as shared
+
+    shared_names = {
+        name: obj for name, obj in vars(shared).items() if not name.startswith("_") and isinstance(obj, type)
+    }
+    offenders = []
+    for mod_name, mod in _platform_ipc_modules().items():
+        for name, shared_obj in shared_names.items():
+            local = getattr(mod, name, None)
+            if local is None or local is shared_obj:
+                continue  # absent, or the shared class re-exported -- both fine
+            if not (isinstance(local, type) and issubclass(local, shared_obj)):
+                offenders.append(f"{mod_name}.{name} shadows yazses.ipc.client.{name} without subclassing it")
+    assert not offenders, "\n".join(
+        [
+            "A platform transport redeclared a name its callers catch by identity.",
+            "Subclass the shared class instead of declaring a new one:",
+            *offenders,
+        ]
+    )

--- a/tests/test_windows_daemon_lifecycle_330.py
+++ b/tests/test_windows_daemon_lifecycle_330.py
@@ -130,13 +130,24 @@ def test_wait_until_ready_keeps_polling_through_a_windows_pipe_error():
 # ---- Bug 2: no SIGKILL where there is no SIGKILL --------------------------
 
 
-def test_force_kill_signal_is_sigkill_on_posix():
-    assert cli._force_kill_signal() is signal.SIGKILL
+# Both directions inject the attribute rather than reading the host's, because the
+# host is the one thing these tests must not depend on. Reading `signal.SIGKILL`
+# inside the assertion made the *test* raise `AttributeError` on Windows -- the one
+# platform this whole file is about -- and `delattr(..., raising=True)` failed there
+# for the opposite reason: the attribute is already gone. Injecting also makes the
+# assertion stronger, since it proves `_force_kill_signal` returns whatever `getattr`
+# found rather than a constant that happens to match.
+_SENTINEL_SIGKILL = 9
+
+
+def test_force_kill_signal_returns_the_signal_where_one_exists(monkeypatch):
+    monkeypatch.setattr(signal, "SIGKILL", _SENTINEL_SIGKILL, raising=False)
+    assert cli._force_kill_signal() == _SENTINEL_SIGKILL
 
 
 def test_force_kill_signal_is_none_where_the_attribute_is_absent(monkeypatch):
-    """Simulate Windows by removing the attribute Windows does not have."""
-    monkeypatch.delattr(signal, "SIGKILL", raising=True)
+    """Windows has no `SIGKILL`; `raising=False` so this also holds *on* Windows."""
+    monkeypatch.delattr(signal, "SIGKILL", raising=False)
     assert cli._force_kill_signal() is None
 
 
@@ -160,7 +171,7 @@ def test_restart_does_not_touch_sigkill_on_a_platform_without_it(monkeypatch):
     the daemon was left running with the *old* config, which is the stale
     `right_ctrl` hotkey the reporter saw.
     """
-    monkeypatch.delattr(signal, "SIGKILL", raising=True)
+    monkeypatch.delattr(signal, "SIGKILL", raising=False)
     monkeypatch.setattr(cli, "_systemd_managed", lambda: False)
     monkeypatch.setattr(cli, "_kill_yazses_daemons", lambda _sig: 0)
 
@@ -201,8 +212,13 @@ def test_restart_does_not_touch_sigkill_on_a_platform_without_it(monkeypatch):
     assert spawned == [plat], "restart must still end with exactly one daemon spawned"
 
 
-def test_restart_still_force_kills_on_posix(monkeypatch):
-    """The fix must not quietly weaken the Linux path it was protecting."""
+def test_restart_still_force_kills_where_a_kill_signal_exists(monkeypatch):
+    """The fix must not quietly weaken the Linux path it was protecting.
+
+    The signal is injected for the same reason as above: this assertion used to
+    name `signal.SIGKILL` directly and therefore could not run on Windows.
+    """
+    monkeypatch.setattr(signal, "SIGKILL", _SENTINEL_SIGKILL, raising=False)
     monkeypatch.setattr(cli, "_systemd_managed", lambda: False)
     sent = []
     monkeypatch.setattr(cli, "_kill_yazses_daemons", lambda sig: sent.append(sig) or 0)
@@ -234,7 +250,7 @@ def test_restart_still_force_kills_on_posix(monkeypatch):
     with tempfile.TemporaryDirectory() as tmp:
         cli._restart_daemon(_Platform(Path(tmp)))
 
-    assert sent == [signal.SIGTERM, signal.SIGKILL]
+    assert sent == [signal.SIGTERM, _SENTINEL_SIGKILL]
 
 
 # ---- The general form: no platform transport may shadow a shared IPC name ----


### PR DESCRIPTION
Fixes both bugs in #330. Reported by @fall-water-zxc, whose report reproduced on two independent install routes before filing — which is what ruled out Scoop as the cause.

Your diagnosis in the issue was complete and I followed it. You offered the reporter first refusal; it is two days on with no claim, and the diagnosis named the fix, so this is the fix. Happy to close it unclaimed if @fall-water-zxc would rather take it.

## Bug 1 — `start` reported an IPC failure for a daemon that started fine

Two different classes with the same name, no inheritance between them:

| | class | raised / caught |
|---|---|---|
| every caller imports | `yazses.ipc.client.IpcUnreachableError` | caught |
| the pipe client raised | `yazses.platform.windows.ipc.IpcUnreachableError` | raised |

`windows.ipc.IpcUnreachableError` now subclasses the shared one and imports `IpcCallError` instead of re-declaring it. The single assertion that was `False` and is now `True`:

```python
issubclass(win_ipc.IpcUnreachableError, IpcUnreachableError)
```

**This repairs fourteen commands, not one.** `cli.py` has 14 `except IpcUnreachableError:` sites — `status`, `stop`, `doctor`, `logs`, the tray poll — plus `tray/app.py`, `mcp/server.py` and `platform/windows/lifecycle.py`. All were dead code on Windows and graceful on Linux and macOS.

## Bug 2 — `restart` crashed on `signal.SIGKILL`

The guard exists and was unreachable, exactly as you wrote: the argument is evaluated before the call.

```python
_kill_yazses_daemons(signal.SIGKILL)   # AttributeError on Windows, before the guard
```

Now resolved through `_force_kill_signal()`, which returns `None` where `signal` has no `SIGKILL`. `_kill_yazses_daemons(None)` is a no-op, so no caller branches on the platform.

`None` rather than a fallback to `SIGTERM` is deliberate: the caller has already sent `SIGTERM` one second earlier, and a second `SIGTERM` is not a force-kill. On Linux nothing changes — a test asserts the sequence is still `[SIGTERM, SIGKILL]`, so the fix cannot quietly weaken the path it was protecting.

Bug 3 (the stale `right_ctrl`) needed no code: it is a consequence of bug 2, as you said. `restart` reloads the config, `restart` crashed, so the old daemon survived with the old hotkey.

## Tests — 11, all running on Linux, 9 failing against main

`tests/test_windows_daemon_lifecycle_330.py`. The defects were Windows-only; their causes are plain Python, so nothing here needs Windows, pywin32, a named pipe, a daemon or a microphone. Windows' absence of `SIGKILL` is simulated with `monkeypatch.delattr(signal, "SIGKILL")`.

Against `main` (stashing `src/` only, keeping the tests):

```
9 failed, 2 passed in 2.03s
E   AttributeError: module 'signal' has no attribute 'SIGKILL'
src/yazses/cli.py:1029: AttributeError
```

That is the reporter's traceback, reproduced by the suite on Linux. On this branch: `11 passed in 0.91s`.

Beyond the two unit-level assertions, `test_wait_until_ready_keeps_polling_through_a_windows_pipe_error` drives the actual `start` path with the Windows error and asserts it reaches `ready`, and `test_restart_does_not_touch_sigkill_on_a_platform_without_it` asserts `restart` completes and still spawns exactly one daemon.

## Gates

| gate | result |
|---|---|
| `uv run python -m pytest tests/ -q` | **14607 passed**, 354 skipped, 2 failed — both pre-existing, see below |
| `uv run ruff check src tests scripts` | All checks passed |
| `uv run mypy src` | 12 errors → **down from 13 on main** |

The two failures reproduce identically with `src/` stashed, so they are not from this change:

- `test_doctor_names_portaudio` — no PortAudio on this machine, an environment artefact.
- `test_sbom.py::test_the_privacy_statement_scope_counts_match_the_sbom` — `optional` is 167 in `docs/privacy-statement.md` and 168 in `sbom.cdx.json`. **`main` is red here independently of this PR**, and one off-by-one in a published count is the kind of drift that test exists to catch. Left alone deliberately: it is unrelated to #330 and belongs in its own commit.

mypy going from 13 to 12 is incidental — widening `socket_path` to `Path | str` removed a genuine type error on the Windows call site, which had been passing a `str`.

## No AI attribution, per AGENTS.md

No `Co-Authored-By`, no generated-with footer, anywhere in the commit or this PR.

## What I have not verified, and it is the acceptance criterion

**I have no Windows machine.** Everything above is Linux. The causes are platform-independent and the tests prove the mechanisms, but nobody has yet watched `yazses start` print no traceback and `yazses restart` complete on real Windows 11 — and that is the thing the issue is actually about. @fall-water-zxc is the one person here who has reproduced it on two install routes; if they run this branch and confirm the hotkey change survives a `restart`, the issue is closed rather than merely patched.
