### PR TITLE
docs(fedora): the COPR is live, and a container build cannot prove it will work

### DIFF
--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -313,15 +313,34 @@ sudo dnf install yazses
 yazses doctor
 ```
 
+The repository is **live** at
+[copr.fedorainfracloud.org/coprs/mskazemi/yazses](https://copr.fedorainfracloud.org/coprs/mskazemi/yazses/),
+serving **2.36.0** for Fedora 43 and 44 (x86_64 and aarch64) and EPEL 10 (x86_64).
+
+**EPEL 9 is not offered**, and that is a limitation rather than an oversight: it ships
+Python 3.9, so `python3-devel >= 3.11` cannot be satisfied there. RHEL 9 users need
+another route — `pipx install yazses` under a Python 3.11+ interpreter (RHEL 9 ships
+`python3.11` as a separate package) is the practical one. The three commands above were run end to end in a clean
+`fedora:43` container: `dnf copr enable` → `dnf install` → `yazses --version`
+printing `yazses 2.36.0`.
+
 The spec lives at
-[`packaging/fedora/yazses.spec`](https://github.com/MSKazemi/yazses/blob/main/packaging/fedora/yazses.spec)
-and builds a package that has been installed and run on a clean Fedora 41
-container — `packaging/fedora/build-and-test.sh` is that test, and it is meant to
-be run in a container rather than on your machine:
+[`packaging/fedora/yazses.spec`](https://github.com/MSKazemi/yazses/blob/main/packaging/fedora/yazses.spec).
+`packaging/fedora/build-and-test.sh` builds and installs it locally, and is meant
+to be run in a container rather than on your machine:
 
 ```bash
-podman run --rm -v "$PWD:/src:z" fedora:41 /src/packaging/fedora/build-and-test.sh
+podman run --rm -v "$PWD:/src:z" fedora:43 /src/packaging/fedora/build-and-test.sh
 ```
+
+!!! note "That local test cannot catch everything"
+
+    Docker and podman give a build network access by default; COPR does not. Because
+    `%install` runs pip to populate the bundled virtualenv, the first COPR build failed
+    where the container build had passed — and it failed as
+    `No matching distribution found for hatchling`, which reads like a missing
+    dependency rather than a missing network. The project now sets
+    `--enable-net on`. Only a real COPR build could have found it.
 
 Two honest notes about this package:
 

--- a/packaging/fedora/build-and-test.sh
+++ b/packaging/fedora/build-and-test.sh
@@ -5,8 +5,8 @@
 # build on a clean Fedora, install the RPM, run `yazses doctor`. It is meant to
 # be executed INSIDE a Fedora container so nothing touches the host:
 #
-#   podman run --rm -v "$PWD:/src:z" fedora:41 /src/packaging/fedora/build-and-test.sh
-#   docker run --rm -v "$PWD:/src"    fedora:41 /src/packaging/fedora/build-and-test.sh
+#   podman run --rm -v "$PWD:/src:z" fedora:43 /src/packaging/fedora/build-and-test.sh
+#   docker run --rm -v "$PWD:/src"    fedora:43 /src/packaging/fedora/build-and-test.sh
 #
 # `yazses doctor` exits non-zero on a container (no audio device, no session), and
 # that is the correct answer there — what is being verified is that the package

--- a/packaging/fedora/yazses.spec
+++ b/packaging/fedora/yazses.spec
@@ -17,7 +17,25 @@
 # much larger job than this file.
 #
 # Build and test it exactly the way CI does:
-#   podman run --rm -v "$PWD:/src:z" fedora:41 /src/packaging/fedora/build-and-test.sh
+#   podman run --rm -v "$PWD:/src:z" fedora:43 /src/packaging/fedora/build-and-test.sh
+#
+# ⚠ COPR REQUIRES `--enable-net on` FOR THIS PACKAGE.
+#
+# %install runs pip to populate the bundled virtualenv, so the build needs to reach
+# PyPI. COPR disables network in the mock chroot by default, and the failure is not
+# obviously about networking -- it surfaces as "ERROR: No matching distribution found
+# for hatchling", which reads like a missing BuildRequires. The real message is further
+# up the log: "Failed to establish a new connection: [Errno -3] Temporary failure in
+# name resolution".
+#
+# A container build passes regardless, because Docker and podman give the build network
+# by default. So the local harness above CANNOT catch this; only a real COPR build can.
+# It cost one failed build (10980673) to find, and the fix is a project setting rather
+# than a spec change:
+#
+#   copr-cli modify yazses --enable-net on
+#
+# Live: https://copr.fedorainfracloud.org/coprs/mskazemi/yazses/
 
 %global appname yazses
 %global venvdir %{_libdir}/%{appname}


### PR DESCRIPTION
## The COPR is live

`docs/install-linux.md` has documented `dnf copr enable mskazemi/yazses` since the spec was written. **The repository did not exist**, so those three commands could not have worked for anyone who tried them.

It exists now — https://copr.fedorainfracloud.org/coprs/mskazemi/yazses/ — serving **2.36.0** for Fedora 43 & 44 (x86_64 + aarch64) and EPEL 10 (x86_64). Verified end to end in a clean `fedora:43` container:

```
dnf copr enable mskazemi/yazses
dnf install yazses
→ yazses-2.36.0-1.fc43.x86_64
→ yazses 2.36.0
```

## What the local harness could not catch

Docker and podman give a build **network access by default. COPR's mock chroot does not.** `%install` runs pip to populate the bundled virtualenv, so the first COPR build failed precisely where the container build had passed.

It failed as:

```
ERROR: No matching distribution found for hatchling
```

which reads like a missing `BuildRequires`. The real cause was further up the log:

```
Failed to establish a new connection: [Errno -3] Temporary failure in name resolution
```

The fix is a project setting, not a spec change — `copr-cli modify yazses --enable-net on` — and it is now recorded in the spec header so nobody pays for it twice.

## EPEL 9 dropped, deliberately

EPEL 9 ships Python 3.9 and the spec needs `python3-devel >= 3.11`, which is unsatisfiable there. The chroot could only ever be red, so it is removed rather than left failing, and the page names the limitation and points RHEL 9 users at a 3.11 interpreter instead of implying the COPR covers them.

## Fedora 41 → 43

Fedora 41 is EOL and COPR offers no chroot for it, so `build-and-test.sh` was testing against something nobody can build on any more.

## Build results

| Chroot | |
|---|---|
| fedora-43-x86_64 | ✅ |
| fedora-44-x86_64 | ✅ |
| fedora-43-aarch64 | ✅ |
| fedora-44-aarch64 | ✅ |
| epel-10-x86_64 | ✅ |
| epel-9-x86_64 | ❌ Python 3.9 — chroot removed |

```
pytest shipped_links + advised_commands → 1453 passed
pytest docs frontmatter/nav/changelog   → 618 passed
ruff check src tests scripts            → All checks passed!
```
